### PR TITLE
Split deployment and build to only deploy when pushing to master

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,17 @@
-assembly_info:
-  patch: false
-build_script:
-  build.cmd
-test: off
-deploy_script:
-  build.cmd "PublishNugetPackage" nugetKey=%nugetKey%
+# CI steps for all branches:
+-
+  version: 1.0.{build}
+  assembly_info:
+    patch: false
+  build_script:
+    build.cmd version="{version}"
+  test: off
+
+# For master only:
+-
+  branches:
+    only:
+      - master
+
+  deploy_script:
+    build.cmd "PublishNugetPackage" -st nugetKey=%nugetKey% version="{version}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
   assembly_info:
     patch: false
   build_script:
-    build.cmd version="{version}"
+    build.cmd version=%APPVEYOR_BUILD_VERSION%
   test: off
 
 # For master only:
@@ -14,4 +14,4 @@
       - master
 
   deploy_script:
-    build.cmd "PublishNugetPackage" -st nugetKey=%nugetKey% version="{version}"
+    build.cmd "PublishNugetPackage" -st nugetKey=%nugetKey% version=%APPVEYOR_BUILD_VERSION%

--- a/build.fsx
+++ b/build.fsx
@@ -14,7 +14,7 @@ let projectReferences = !! "./source/**/*.csproj"
                         -- "./source/Nrk.HttpRequester.UnitTests/*.csproj"
 let projectName = "NRK.HttpRequester"
 let description = "Library for sending Http Requests, including a fluent interface for creating HttpClient instances"
-let version = "1.0.0"
+let version = environVarOrDefault "version" "1.0.0"
 let commitHash = Information.getCurrentSHA1(".")
 
 Target "Clean" (fun _ ->

--- a/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersionAttribute("1.0.0")]
 [assembly: AssemblyFileVersionAttribute("1.0.0")]
 [assembly: GuidAttribute("d51e7a23-73d5-49a1-be63-f73e432e9ab3")]
-[assembly: AssemblyMetadataAttribute("githash","a6a4b42132c0e867545408d5e149a624f1958252")]
+[assembly: AssemblyMetadataAttribute("githash","df607ccdd20d7d6946fc93bc382c4734a81a3be5")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "NRK.HttpRequester";
@@ -19,6 +19,6 @@ namespace System {
         internal const System.String AssemblyInformationalVersion = "1.0.0";
         internal const System.String AssemblyFileVersion = "1.0.0";
         internal const System.String Guid = "d51e7a23-73d5-49a1-be63-f73e432e9ab3";
-        internal const System.String AssemblyMetadata_githash = "a6a4b42132c0e867545408d5e149a624f1958252";
+        internal const System.String AssemblyMetadata_githash = "df607ccdd20d7d6946fc93bc382c4734a81a3be5";
     }
 }


### PR DESCRIPTION
Split deployment and CI builds to only publish a NuGet package when pushing to the master branch.

Will use build number from AppVeyor for versioning the package.