### PR TITLE
Add integration tests

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -7,11 +7,10 @@ open Fake.MSBuildHelper
 open Fake.Testing.XUnit2
 
 let buildDir = "./build/"
-let testDir = "./source/Nrk.HttpRequester.UnitTests"
+let testProjects = "./source/*Tests/*.csproj"
 let testOutputDir = "./tests/"
 let packageConfigs = !! "./source/**/packages.config"
-let projectReferences = !! "./source/**/*.csproj"
-                        -- "./source/Nrk.HttpRequester.UnitTests/*.csproj"
+let projectReferences = !! "./source/Nrk.HttpRequester/*.csproj"
 let projectName = "NRK.HttpRequester"
 let description = "Library for sending Http Requests, including a fluent interface for creating HttpClient instances"
 let version = environVarOrDefault "version" "0.0.0"
@@ -43,13 +42,13 @@ Target "Build" (fun _ ->
 )
 
 Target "BuildTests" (fun _ ->
-  !! (testDir + "/*.csproj")
+  !! testProjects
     |> MSBuildDebug testOutputDir "Build"
     |> Log "Building test project: "
 )
 
 Target "Test" (fun _ ->
-  !! (testOutputDir @@ "*UnitTests.dll")
+  !! (testOutputDir @@ "*Tests.dll")
   |> xUnit2 (fun p ->
                  { p with HtmlOutputPath = Some (testOutputDir @@ "xunit.html") })
 )

--- a/source/Nrk.HttpRequester.IntegrationTests/.editorconfig
+++ b/source/Nrk.HttpRequester.IntegrationTests/.editorconfig
@@ -1,0 +1,7 @@
+[*]
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{fsx,cs}]
+indent_style = space
+indent_size = 4

--- a/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
+++ b/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
@@ -1,0 +1,135 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{6CB63FCF-96C2-45C5-B719-BB267341C0CF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Nrk.HttpRequester.IntegrationTests</RootNamespace>
+    <AssemblyName>Nrk.HttpRequester.IntegrationTests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Nancy.Owin, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.Owin.1.4.1\lib\net40\Nancy.Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
+      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.2.8.2\lib\net451\Shouldly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.0.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="TestServer\Server.cs" />
+    <Compile Include="WebRequesterIntegrationTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include=".editorconfig" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Nrk.HttpRequester\Nrk.HttpRequester.csproj">
+      <Project>{372CFF1E-9336-4E40-8648-0B96C54687D1}</Project>
+      <Name>Nrk.HttpRequester</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
+++ b/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
@@ -35,6 +35,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
       <Private>True</Private>

--- a/source/Nrk.HttpRequester.IntegrationTests/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Nrk.HttpRequester.IntegrationTests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Nrk.HttpRequester.IntegrationTests")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("6cb63fcf-96c2-45c5-b719-bb267341c0cf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -13,8 +13,7 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
 
             Get["/delay/{ms:int}"] = parameters =>
             {
-                var delay = (int)parameters.ms;
-                Thread.Sleep(delay);
+                Thread.Sleep(parameters.ms);
                 return $"Finished sleeping for {parameters.ms}ms";
             };
 

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -1,4 +1,6 @@
-﻿using Nancy;
+﻿using System.Linq;
+using System.Threading;
+using Nancy;
 using Owin;
 
 namespace Nrk.HttpRequester.IntegrationTests.TestServer
@@ -8,6 +10,19 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
         public ServerModule()
         {
             Get["/"] = _ => "success";
+
+            Get["/delay/{ms:int}"] = parameters =>
+            {
+                var delay = (int)parameters.ms;
+                Thread.Sleep(delay);
+                return $"Finished sleeping for{parameters.ms}ms";
+            };
+
+            Get["/headers"] = _ =>
+            {
+                var headers = Request.Headers.ToArray();
+                return Response.AsJson(headers);
+            };
         }
     }
 

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -1,0 +1,21 @@
+﻿using Nancy;
+using Owin;
+
+namespace Nrk.HttpRequester.IntegrationTests.TestServer
+{
+    public class ServerModule : NancyModule
+    {
+        public ServerModule()
+        {
+            Get["/"] = _ => "success";
+        }
+    }
+
+    public class Startup
+    {
+        public void Configuration(IAppBuilder appBuilder)
+        {
+            appBuilder.UseNancy();
+        }
+    }
+}

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -15,7 +15,7 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
             {
                 var delay = (int)parameters.ms;
                 Thread.Sleep(delay);
-                return $"Finished sleeping for{parameters.ms}ms";
+                return $"Finished sleeping for {parameters.ms}ms";
             };
 
             Get["/headers"] = _ =>

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Owin.Hosting;
+using Nrk.HttpRequester.IntegrationTests.TestServer;
+using Shouldly;
+using Xunit;
+
+namespace Nrk.HttpRequester.IntegrationTests
+{
+    public class WebRequesterIntegrationTests : IDisposable
+    {
+        private readonly IDisposable _webApp;
+        private const string Url = "http://localhost:9001";
+        public WebRequesterIntegrationTests()
+        {
+            _webApp = WebApp.Start<Startup>(Url);
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_ShouldGetResponseFromServer()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+            var response = await webRequester.GetResponseAsync("");
+            response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        public void Dispose()
+        {
+            _webApp.Dispose();
+        }
+    }
+}

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -12,6 +12,7 @@ namespace Nrk.HttpRequester.IntegrationTests
     {
         private readonly IDisposable _webApp;
         private const string Url = "http://localhost:9001";
+
         public WebRequesterIntegrationTests()
         {
             _webApp = WebApp.Start<Startup>(Url);

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
 using Nrk.HttpRequester.IntegrationTests.TestServer;
@@ -22,8 +23,43 @@ namespace Nrk.HttpRequester.IntegrationTests
             // Arrange
             var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
             var webRequester = new WebRequester(httpClient);
+
+            // Act
             var response = await webRequester.GetResponseAsync("");
+
+            // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_ShouldTimeoutOnSlowResponse()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).WithTimeout(TimeSpan.FromMilliseconds(100)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            // Act
+            var exception = await Record.ExceptionAsync(async () => await webRequester.GetResponseAsync("/delay/250"));
+
+            // Assert
+            exception.ShouldBeOfType(typeof(TaskCanceledException));
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_ShouldSetDefaultHeaders()
+        {
+            // Arrange
+            var httpClient =
+                WebRequestHttpClientFactory.Configure(new Uri(Url))
+                    .WithDefaultRequestHeaders(new Dictionary<string, string> { { "fakeHeader", "fakeValue" } })
+                    .Create();
+            var webRequester = new WebRequester(httpClient);
+
+            // Act
+            var response = await webRequester.GetResponseAsStringAsync("/headers");
+
+            // Assert
+            response.Contains("fakeHeader").ShouldBeTrue();
         }
 
         public void Dispose()

--- a/source/Nrk.HttpRequester.IntegrationTests/packages.config
+++ b/source/Nrk.HttpRequester.IntegrationTests/packages.config
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
+  <package id="Nancy" version="1.4.1" targetFramework="net452" />
+  <package id="Nancy.Owin" version="1.4.1" targetFramework="net452" />
+  <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="Shouldly" version="2.8.2" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.0.0" targetFramework="net452" />
+</packages>

--- a/source/Nrk.HttpRequester.sln
+++ b/source/Nrk.HttpRequester.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{879D3C33
 		..\build.fsx = ..\build.fsx
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nrk.HttpRequester.IntegrationTests", "Nrk.HttpRequester.IntegrationTests\Nrk.HttpRequester.IntegrationTests.csproj", "{6CB63FCF-96C2-45C5-B719-BB267341C0CF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{1AE95B3A-D396-40AD-BABE-E25352A0EAF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1AE95B3A-D396-40AD-BABE-E25352A0EAF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1AE95B3A-D396-40AD-BABE-E25352A0EAF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6CB63FCF-96C2-45C5-B719-BB267341C0CF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6CB63FCF-96C2-45C5-B719-BB267341C0CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6CB63FCF-96C2-45C5-B719-BB267341C0CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6CB63FCF-96C2-45C5-B719-BB267341C0CF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Adding an integration test project. Using a self-hosted [Nancy](http://nancyfx.org/) module to run the integration tests.

This server currently supports 3 endpoints:
* `/` - Returns 200 OK and a textual "success" in the body.
* `/delay/{ms:int}` - Returns 200 OK after the specified amount of time in milliseconds.
* `/headers` - Returns 200 OK and a JSON array containing the headers sent in the request.

Currently have tests for a simple request, timeouts and default headers