### PR TITLE
Add support for HTTP Delete, Put and Post

### DIFF
--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -19,41 +19,17 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
 
             Delete["/"] = _ => "success";
 
-            Put["/headers"] = _ => 
-            {
-                var headers = Request.Headers.ToArray();
-                return Response.AsJson(headers);
-            };
+            Put["/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
+            
+            Post["/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
 
-            Post["/headers"] = _ =>
-            {
-                var headers = Request.Headers.ToArray();
-                return Response.AsJson(headers);
-            };
+            Delete["/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
 
-            Delete["/headers"] = _ =>
-            {
-                var headers = Request.Headers.ToArray();
-                return Response.AsJson(headers);
-            };
+            Put["/content"] = _ => Request.Body.AsString();
 
-            Put["/content"] = _ =>
-            {
-                var body = Request.Body;
-                return body.AsString();
-            };
-
-            Post["/content"] = _ =>
-            {
-                var body = Request.Body;
-                return body.AsString();
-            };
-
-            Delete["/content"] = _ =>
-            {
-                var body = Request.Body;
-                return body.AsString();
-            };
+            Post["/content"] = _ => Request.Body.AsString();
+            
+            Delete["/content"] = _ => Request.Body.AsString();
 
             Get["/delay/{ms:int}"] = parameters =>
             {

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -15,13 +15,41 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
 
             Put["/"] = _ => "success";
 
+            Post["/"] = _ => "success";
+
+            Delete["/"] = _ => "success";
+
             Put["/headers"] = _ => 
             {
                 var headers = Request.Headers.ToArray();
                 return Response.AsJson(headers);
             };
 
+            Post["/headers"] = _ =>
+            {
+                var headers = Request.Headers.ToArray();
+                return Response.AsJson(headers);
+            };
+
+            Delete["/headers"] = _ =>
+            {
+                var headers = Request.Headers.ToArray();
+                return Response.AsJson(headers);
+            };
+
             Put["/content"] = _ =>
+            {
+                var body = Request.Body;
+                return body.AsString();
+            };
+
+            Post["/content"] = _ =>
+            {
+                var body = Request.Body;
+                return body.AsString();
+            };
+
+            Delete["/content"] = _ =>
             {
                 var body = Request.Body;
                 return body.AsString();

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -1,6 +1,8 @@
 ﻿using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using Nancy;
+using Nancy.Extensions;
 using Owin;
 
 namespace Nrk.HttpRequester.IntegrationTests.TestServer
@@ -10,6 +12,20 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
         public ServerModule()
         {
             Get["/"] = _ => "success";
+
+            Put["/"] = _ => "success";
+
+            Put["/headers"] = _ => 
+            {
+                var headers = Request.Headers.ToArray();
+                return Response.AsJson(headers);
+            };
+
+            Put["/content"] = _ =>
+            {
+                var body = Request.Body;
+                return body.AsString();
+            };
 
             Get["/delay/{ms:int}"] = parameters =>
             {

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -82,8 +82,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PutAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             var content = new StringContent("");
             const string authorizationScheme = "bearer";
@@ -92,16 +91,14 @@ namespace Nrk.HttpRequester.IntegrationTests
             var response = await webRequester.PutAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
-            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
-            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+            VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
         }
 
         [Fact]
         public async Task PutAsync_ShouldSetContent()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             const string exampleContent = "Sample content";
             // Act
@@ -116,8 +113,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PostAsync_ShouldGetResponseFromServer()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             // Act
             var response = await webRequester.PostAsync("", new StringContent("test"), "", "");
@@ -130,8 +126,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PostAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             var content = new StringContent("");
             const string authorizationScheme = "bearer";
@@ -140,16 +135,14 @@ namespace Nrk.HttpRequester.IntegrationTests
             var response = await webRequester.PostAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
-            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
-            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+            VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
         }
 
         [Fact]
         public async Task PostAsync_ShouldSetContent()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             const string exampleContent = "Sample content";
             // Act
@@ -164,8 +157,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task DeleteAsync_ShouldGetResponseFromServer()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             // Act
             var response = await webRequester.DeleteAsync("", new StringContent("test"), "", "");
@@ -178,8 +170,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task DeleteAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             var content = new StringContent("");
             const string authorizationScheme = "bearer";
@@ -189,16 +180,14 @@ namespace Nrk.HttpRequester.IntegrationTests
             var response = await webRequester.DeleteAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
-            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
-            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+            VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
         }
 
         [Fact]
         public async Task DeleteAsync_ShouldSetContent()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
+            var webRequester = SetupWebRequester();
 
             const string exampleContent = "Sample content";
             // Act
@@ -207,6 +196,18 @@ namespace Nrk.HttpRequester.IntegrationTests
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
             actualContent.ShouldBe(exampleContent);
+        }
+
+        private static void VerifyAuthorizationHeader(HttpResponseMessage response, string authorizationScheme, string accessToken)
+        {
+            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
+            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+        }
+
+        private static IWebRequester SetupWebRequester()
+        {
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            return new WebRequester(httpClient);
         }
 
         public void Dispose()

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -72,7 +72,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             var webRequester = new WebRequester(httpClient);
 
             // Act
-            var response = await webRequester.PutAsync("", "", "", new StringContent("test"));
+            var response = await webRequester.PutAsync("", new StringContent("test"), "", "");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -89,7 +89,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await webRequester.PutAsync("/headers", authorizationScheme, accessToken, content);
+            var response = await webRequester.PutAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
             response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
@@ -105,7 +105,7 @@ namespace Nrk.HttpRequester.IntegrationTests
 
             const string exampleContent = "Sample content";
             // Act
-            var response = await webRequester.PutAsync("/content", "", "", new StringContent(exampleContent));
+            var response = await webRequester.PutAsync("/content", new StringContent(exampleContent), "", "");
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -120,7 +120,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             var webRequester = new WebRequester(httpClient);
 
             // Act
-            var response = await webRequester.PostAsync("", "", "", new StringContent("test"));
+            var response = await webRequester.PostAsync("", new StringContent("test"), "", "");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -137,7 +137,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await webRequester.PostAsync("/headers", authorizationScheme, accessToken, content);
+            var response = await webRequester.PostAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
             response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
@@ -153,7 +153,7 @@ namespace Nrk.HttpRequester.IntegrationTests
 
             const string exampleContent = "Sample content";
             // Act
-            var response = await webRequester.PostAsync("/content", "", "", new StringContent(exampleContent));
+            var response = await webRequester.PostAsync("/content", new StringContent(exampleContent), "", "");
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -168,7 +168,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             var webRequester = new WebRequester(httpClient);
 
             // Act
-            var response = await webRequester.DeleteAsync("", "", "", new StringContent("test"));
+            var response = await webRequester.DeleteAsync("", new StringContent("test"), "", "");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -186,7 +186,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string accessToken = "accessToken";
 
             // Act
-            var response = await webRequester.DeleteAsync("/headers", authorizationScheme, accessToken, content);
+            var response = await webRequester.DeleteAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
             response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
@@ -202,7 +202,7 @@ namespace Nrk.HttpRequester.IntegrationTests
 
             const string exampleContent = "Sample content";
             // Act
-            var response = await webRequester.DeleteAsync("/content", "", "", new StringContent(exampleContent));
+            var response = await webRequester.DeleteAsync("/content", new StringContent(exampleContent), "", "");
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
 using Nrk.HttpRequester.IntegrationTests.TestServer;
@@ -66,7 +67,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PutAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.PutAsync("", new StringContent("test"), "", "");
+            var response = await _webRequester.PutAsync("", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -80,7 +81,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await _webRequester.PutAsync("/headers", content, authorizationScheme, accessToken);
+            var response = await _webRequester.PutAsync("/headers", content, new AuthenticationHeaderValue(authorizationScheme, accessToken));
 
             // Assert
             VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
@@ -92,7 +93,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             // Arrange
             const string exampleContent = "Sample content";
             // Act
-            var response = await _webRequester.PutAsync("/content", new StringContent(exampleContent), "", "");
+            var response = await _webRequester.PutAsync("/content", new StringContent(exampleContent));
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -103,7 +104,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PostAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.PostAsync("", new StringContent("test"), "", "");
+            var response = await _webRequester.PostAsync("", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -117,7 +118,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await _webRequester.PostAsync("/headers", content, authorizationScheme, accessToken);
+            var response = await _webRequester.PostAsync("/headers", content, new AuthenticationHeaderValue(authorizationScheme, accessToken));
 
             // Assert
             VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
@@ -129,7 +130,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             // Arrange
             const string exampleContent = "Sample content";
             // Act
-            var response = await _webRequester.PostAsync("/content", new StringContent(exampleContent), "", "");
+            var response = await _webRequester.PostAsync("/content", new StringContent(exampleContent));
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -140,7 +141,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task DeleteAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.DeleteAsync("", new StringContent("test"), "", "");
+            var response = await _webRequester.DeleteAsync("", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -155,7 +156,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string accessToken = "accessToken";
 
             // Act
-            var response = await _webRequester.DeleteAsync("/headers", content, authorizationScheme, accessToken);
+            var response = await _webRequester.DeleteAsync("/headers", content, new AuthenticationHeaderValue(authorizationScheme, accessToken));
 
             // Assert
             VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
@@ -168,7 +169,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string exampleContent = "Sample content";
 
             // Act
-            var response = await _webRequester.DeleteAsync("/content", new StringContent(exampleContent), "", "");
+            var response = await _webRequester.DeleteAsync("/content", new StringContent(exampleContent));
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -12,25 +12,13 @@ namespace Nrk.HttpRequester.IntegrationTests
     public class WebRequesterIntegrationTests : IDisposable
     {
         private readonly IDisposable _webApp;
+        private readonly IWebRequester _webRequester;
         private const string Url = "http://localhost:9001";
 
         public WebRequesterIntegrationTests()
         {
             _webApp = WebApp.Start<Startup>(Url);
-        }
-
-        [Fact]
-        public async Task GetResponseAsync_ShouldGetResponseFromServer()
-        {
-            // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
-
-            // Act
-            var response = await webRequester.GetResponseAsync("");
-
-            // Assert
-            response.IsSuccessStatusCode.ShouldBeTrue();
+            _webRequester = new WebRequester(WebRequestHttpClientFactory.Configure(new Uri(Url)).Create());
         }
 
         [Fact]
@@ -65,14 +53,20 @@ namespace Nrk.HttpRequester.IntegrationTests
         }
 
         [Fact]
+        public async Task GetResponseAsync_ShouldGetResponseFromServer()
+        {
+            // Act
+            var response = await _webRequester.GetResponseAsync("");
+
+            // Assert
+            response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        [Fact]
         public async Task PutAsync_ShouldGetResponseFromServer()
         {
-            // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            var webRequester = new WebRequester(httpClient);
-
             // Act
-            var response = await webRequester.PutAsync("", new StringContent("test"), "", "");
+            var response = await _webRequester.PutAsync("", new StringContent("test"), "", "");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -82,13 +76,11 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PutAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
-            var webRequester = SetupWebRequester();
-
             var content = new StringContent("");
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await webRequester.PutAsync("/headers", content, authorizationScheme, accessToken);
+            var response = await _webRequester.PutAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
             VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
@@ -98,11 +90,9 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PutAsync_ShouldSetContent()
         {
             // Arrange
-            var webRequester = SetupWebRequester();
-
             const string exampleContent = "Sample content";
             // Act
-            var response = await webRequester.PutAsync("/content", new StringContent(exampleContent), "", "");
+            var response = await _webRequester.PutAsync("/content", new StringContent(exampleContent), "", "");
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -112,11 +102,8 @@ namespace Nrk.HttpRequester.IntegrationTests
         [Fact]
         public async Task PostAsync_ShouldGetResponseFromServer()
         {
-            // Arrange
-            var webRequester = SetupWebRequester();
-
             // Act
-            var response = await webRequester.PostAsync("", new StringContent("test"), "", "");
+            var response = await _webRequester.PostAsync("", new StringContent("test"), "", "");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -126,13 +113,11 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PostAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
-            var webRequester = SetupWebRequester();
-
             var content = new StringContent("");
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await webRequester.PostAsync("/headers", content, authorizationScheme, accessToken);
+            var response = await _webRequester.PostAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
             VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
@@ -142,11 +127,9 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PostAsync_ShouldSetContent()
         {
             // Arrange
-            var webRequester = SetupWebRequester();
-
             const string exampleContent = "Sample content";
             // Act
-            var response = await webRequester.PostAsync("/content", new StringContent(exampleContent), "", "");
+            var response = await _webRequester.PostAsync("/content", new StringContent(exampleContent), "", "");
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -156,11 +139,8 @@ namespace Nrk.HttpRequester.IntegrationTests
         [Fact]
         public async Task DeleteAsync_ShouldGetResponseFromServer()
         {
-            // Arrange
-            var webRequester = SetupWebRequester();
-
             // Act
-            var response = await webRequester.DeleteAsync("", new StringContent("test"), "", "");
+            var response = await _webRequester.DeleteAsync("", new StringContent("test"), "", "");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -170,14 +150,12 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task DeleteAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
-            var webRequester = SetupWebRequester();
-
             var content = new StringContent("");
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
 
             // Act
-            var response = await webRequester.DeleteAsync("/headers", content, authorizationScheme, accessToken);
+            var response = await _webRequester.DeleteAsync("/headers", content, authorizationScheme, accessToken);
 
             // Assert
             VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
@@ -187,11 +165,10 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task DeleteAsync_ShouldSetContent()
         {
             // Arrange
-            var webRequester = SetupWebRequester();
-
             const string exampleContent = "Sample content";
+
             // Act
-            var response = await webRequester.DeleteAsync("/content", new StringContent(exampleContent), "", "");
+            var response = await _webRequester.DeleteAsync("/content", new StringContent(exampleContent), "", "");
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();
@@ -202,12 +179,6 @@ namespace Nrk.HttpRequester.IntegrationTests
         {
             response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
             response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
-        }
-
-        private static IWebRequester SetupWebRequester()
-        {
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
-            return new WebRequester(httpClient);
         }
 
         public void Dispose()

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -65,21 +65,21 @@ namespace Nrk.HttpRequester.IntegrationTests
         }
 
         [Fact]
-        public async Task PutDataAsync_ShouldGetResponseFromServer()
+        public async Task PutAsync_ShouldGetResponseFromServer()
         {
             // Arrange
             var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
             var webRequester = new WebRequester(httpClient);
 
             // Act
-            var response = await webRequester.PutDataAsync("", "", "", new StringContent("test"));
+            var response = await webRequester.PutAsync("", "", "", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
         }
 
         [Fact]
-        public async Task PutDataAsync_ShouldSetAuthorizationHeader()
+        public async Task PutAsync_ShouldSetAuthorizationHeader()
         {
             // Arrange
             var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
@@ -89,7 +89,7 @@ namespace Nrk.HttpRequester.IntegrationTests
             const string authorizationScheme = "bearer";
             const string accessToken = "accessToken";
             // Act
-            var response = await webRequester.PutDataAsync("/headers", authorizationScheme, accessToken, content);
+            var response = await webRequester.PutAsync("/headers", authorizationScheme, accessToken, content);
 
             // Assert
             response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
@@ -97,7 +97,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         }
 
         [Fact]
-        public async Task PutDataAsync_ShouldSetContent()
+        public async Task PutAsync_ShouldSetContent()
         {
             // Arrange
             var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
@@ -105,7 +105,104 @@ namespace Nrk.HttpRequester.IntegrationTests
 
             const string exampleContent = "Sample content";
             // Act
-            var response = await webRequester.PutDataAsync("/content", "", "", new StringContent(exampleContent));
+            var response = await webRequester.PutAsync("/content", "", "", new StringContent(exampleContent));
+
+            // Assert
+            var actualContent = await response.Content.ReadAsStringAsync();
+            actualContent.ShouldBe(exampleContent);
+        }
+
+        [Fact]
+        public async Task PostAsync_ShouldGetResponseFromServer()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            // Act
+            var response = await webRequester.PostAsync("", "", "", new StringContent("test"));
+
+            // Assert
+            response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task PostAsync_ShouldSetAuthorizationHeader()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            var content = new StringContent("");
+            const string authorizationScheme = "bearer";
+            const string accessToken = "accessToken";
+            // Act
+            var response = await webRequester.PostAsync("/headers", authorizationScheme, accessToken, content);
+
+            // Assert
+            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
+            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+        }
+
+        [Fact]
+        public async Task PostAsync_ShouldSetContent()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            const string exampleContent = "Sample content";
+            // Act
+            var response = await webRequester.PostAsync("/content", "", "", new StringContent(exampleContent));
+
+            // Assert
+            var actualContent = await response.Content.ReadAsStringAsync();
+            actualContent.ShouldBe(exampleContent);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldGetResponseFromServer()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            // Act
+            var response = await webRequester.DeleteAsync("", "", "", new StringContent("test"));
+
+            // Assert
+            response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldSetAuthorizationHeader()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            var content = new StringContent("");
+            const string authorizationScheme = "bearer";
+            const string accessToken = "accessToken";
+
+            // Act
+            var response = await webRequester.DeleteAsync("/headers", authorizationScheme, accessToken, content);
+
+            // Assert
+            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
+            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+        }
+
+        [Fact]
+        public async Task DeleteAsync_ShouldSetContent()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            const string exampleContent = "Sample content";
+            // Act
+            var response = await webRequester.DeleteAsync("/content", "", "", new StringContent(exampleContent));
 
             // Assert
             var actualContent = await response.Content.ReadAsStringAsync();

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
 using Nrk.HttpRequester.IntegrationTests.TestServer;
@@ -61,6 +62,54 @@ namespace Nrk.HttpRequester.IntegrationTests
 
             // Assert
             response.Contains("fakeHeader").ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task PutDataAsync_ShouldGetResponseFromServer()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            // Act
+            var response = await webRequester.PutDataAsync("", "", "", new StringContent("test"));
+
+            // Assert
+            response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task PutDataAsync_ShouldSetAuthorizationHeader()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            var content = new StringContent("");
+            const string authorizationScheme = "bearer";
+            const string accessToken = "accessToken";
+            // Act
+            var response = await webRequester.PutDataAsync("/headers", authorizationScheme, accessToken, content);
+
+            // Assert
+            response.RequestMessage.Headers.Authorization.Scheme.ShouldBe(authorizationScheme);
+            response.RequestMessage.Headers.Authorization.Parameter.ShouldBe(accessToken);
+        }
+
+        [Fact]
+        public async Task PutDataAsync_ShouldSetContent()
+        {
+            // Arrange
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).Create();
+            var webRequester = new WebRequester(httpClient);
+
+            const string exampleContent = "Sample content";
+            // Act
+            var response = await webRequester.PutDataAsync("/content", "", "", new StringContent(exampleContent));
+
+            // Assert
+            var actualContent = await response.Content.ReadAsStringAsync();
+            actualContent.ShouldBe(exampleContent);
         }
 
         public void Dispose()

--- a/source/Nrk.HttpRequester.UnitTests/WebRequestHttpClientFactoryTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequestHttpClientFactoryTests.cs
@@ -13,7 +13,6 @@ namespace Nrk.HttpRequester.UnitTests
         {
             // Act
             var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(null).Create());
-
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();
         }
@@ -50,7 +49,7 @@ namespace Nrk.HttpRequester.UnitTests
 
             // Act
             var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithDefaultRequestHeaders(requestHeaders).Create();
-
+            
             // Assert
             httpClient.Client.DefaultRequestHeaders.Contains("headerKey").ShouldBeTrue();
         }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -10,8 +10,8 @@ namespace Nrk.HttpRequester
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> PostDataAsync(string path, string userAccessToken, StringContent content);
-        Task<HttpResponseMessage> PutDataAsync(string path, string userAccessToken, StringContent content);
-        Task<HttpResponseMessage> DeleteAsync(string path, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> PostDataAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> PutDataAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
     }
 }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -13,5 +13,6 @@ namespace Nrk.HttpRequester
         Task<HttpResponseMessage> PostAsync(string path, StringContent content, string authenticationScheme, string accessToken);
         Task<HttpResponseMessage> PutAsync(string path, StringContent content, string authenticationScheme, string accessToken);
         Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, string authenticationScheme, string accessToken);
+        Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string accessToken);
     }
 }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -10,5 +10,8 @@ namespace Nrk.HttpRequester
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
+        Task<HttpResponseMessage> PostDataAsync(string path, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> PutDataAsync(string path, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> DeleteAsync(string path, string userAccessToken, StringContent content);
     }
 }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Specialized;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace Nrk.HttpRequester
@@ -10,9 +11,21 @@ namespace Nrk.HttpRequester
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> PostAsync(string path, StringContent content, string authenticationScheme, string accessToken);
-        Task<HttpResponseMessage> PutAsync(string path, StringContent content, string authenticationScheme, string accessToken);
-        Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, string authenticationScheme, string accessToken);
-        Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string accessToken);
+        Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
+        Task<HttpResponseMessage> PostAsync(string path, StringContent content);
+        Task<HttpResponseMessage> PutAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
+        Task<HttpResponseMessage> PutAsync(string path, StringContent content);
+        Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
+        Task<HttpResponseMessage> DeleteAsync(string path, AuthenticationHeaderValue authenticationHeader);
+        Task<HttpResponseMessage> DeleteAsync(string path, StringContent content);
+        Task<HttpResponseMessage> DeleteAsync(string path);
+        /// <summary>
+        /// Intended for use cases not covered by default methods provided
+        /// Direct access to underlying http client
+        /// </summary>
+        Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request);
+        Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries);
     }
+
+
 }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -10,8 +10,8 @@ namespace Nrk.HttpRequester
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> PostDataAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
-        Task<HttpResponseMessage> PutDataAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> PostAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> PutAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
         Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
     }
 }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -10,8 +10,8 @@ namespace Nrk.HttpRequester
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> PostAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
-        Task<HttpResponseMessage> PutAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
-        Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string userAccessToken, StringContent content);
+        Task<HttpResponseMessage> PostAsync(string path, StringContent content, string authenticationScheme, string accessToken);
+        Task<HttpResponseMessage> PutAsync(string path, StringContent content, string authenticationScheme, string accessToken);
+        Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, string authenticationScheme, string accessToken);
     }
 }

--- a/source/Nrk.HttpRequester/WebRequestHttpClientFactory.cs
+++ b/source/Nrk.HttpRequester/WebRequestHttpClientFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace Nrk.HttpRequester

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -72,7 +72,7 @@ namespace Nrk.HttpRequester
             return requestPolicy.ExecuteAsync(() => PerformGetRequestAsync(urlWithParameters));
         }
 
-        public Task<HttpResponseMessage> PostDataAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        public Task<HttpResponseMessage> PostAsync(string path, string authenticationScheme, string accessToken, StringContent content)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, path);
             SetAuthenticationHeader(request, authenticationScheme, accessToken);
@@ -80,7 +80,7 @@ namespace Nrk.HttpRequester
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> PutDataAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        public Task<HttpResponseMessage> PutAsync(string path, string authenticationScheme, string accessToken, StringContent content)
         {
             var request = new HttpRequestMessage(HttpMethod.Put, path);
             SetAuthenticationHeader(request, authenticationScheme, accessToken);

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -72,35 +72,85 @@ namespace Nrk.HttpRequester
             return requestPolicy.ExecuteAsync(() => PerformGetRequestAsync(urlWithParameters));
         }
 
-        public Task<HttpResponseMessage> PostAsync(string path, StringContent content, string authenticationScheme, string accessToken)
+        public Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, path);
-            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Headers.Authorization = authenticationHeader;
             request.Content = content;
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> PutAsync(string path, StringContent content, string authenticationScheme, string accessToken)
+        public Task<HttpResponseMessage> PostAsync(string path, StringContent content)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, path)
+            {
+                Content = content
+            };
+
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> PutAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Put, path);
-            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Headers.Authorization = authenticationHeader;
             request.Content = content;
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, string authenticationScheme, string accessToken)
+        public Task<HttpResponseMessage> PutAsync(string path, StringContent content)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Put, path)
+            {
+                Content = content
+            };
+
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, path);
-            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Headers.Authorization = authenticationHeader;
             request.Content = content;
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string accessToken)
+        public Task<HttpResponseMessage> DeleteAsync(string path, AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, path);
-            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Headers.Authorization = authenticationHeader;
             return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string path, StringContent content)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete, path)
+            {
+                Content = content
+            };
+
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string path)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Put, path);
+            return _client.SendAsync(request);
+        }
+      
+        public Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request)
+        {
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries)
+        {
+            var requestPolicy = Policy
+                .Handle<TaskCanceledException>()
+                .WaitAndRetryAsync(retries, retryAttempt => _retryTimeout);
+
+            return requestPolicy.ExecuteAsync(() => _client.SendAsync(request));
         }
 
         private Task<HttpResponseMessage> PerformGetRequestAsync(string path)
@@ -108,12 +158,5 @@ namespace Nrk.HttpRequester
             var request = new HttpRequestMessage(HttpMethod.Get, path);
             return _client.SendAsync(request);
         }
-
-        private static void SetAuthenticationHeader(HttpRequestMessage request, string authenticationScheme, string accessToken)
-        {
-            if (string.IsNullOrEmpty(authenticationScheme) || string.IsNullOrEmpty(accessToken)) return;
-            request.Headers.Authorization = new AuthenticationHeaderValue(authenticationScheme, accessToken);
-        }
-
     }
 }

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -72,7 +72,7 @@ namespace Nrk.HttpRequester
             return requestPolicy.ExecuteAsync(() => PerformGetRequestAsync(urlWithParameters));
         }
 
-        public Task<HttpResponseMessage> PostAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        public Task<HttpResponseMessage> PostAsync(string path, StringContent content, string authenticationScheme, string accessToken)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, path);
             SetAuthenticationHeader(request, authenticationScheme, accessToken);
@@ -80,7 +80,7 @@ namespace Nrk.HttpRequester
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> PutAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        public Task<HttpResponseMessage> PutAsync(string path, StringContent content, string authenticationScheme, string accessToken)
         {
             var request = new HttpRequestMessage(HttpMethod.Put, path);
             SetAuthenticationHeader(request, authenticationScheme, accessToken);
@@ -88,11 +88,18 @@ namespace Nrk.HttpRequester
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        public Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, string authenticationScheme, string accessToken)
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, path);
             SetAuthenticationHeader(request, authenticationScheme, accessToken);
             request.Content = content;
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string accessToken)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete, path);
+            SetAuthenticationHeader(request, authenticationScheme, accessToken);
             return _client.SendAsync(request);
         }
 

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Polly;
 
@@ -71,25 +72,41 @@ namespace Nrk.HttpRequester
             return requestPolicy.ExecuteAsync(() => PerformGetRequestAsync(urlWithParameters));
         }
 
+        public Task<HttpResponseMessage> PostDataAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Post, path);
+            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Content = content;
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> PutDataAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Put, path);
+            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Content = content;
+            return _client.SendAsync(request);
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string path, string authenticationScheme, string accessToken, StringContent content)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Delete, path);
+            SetAuthenticationHeader(request, authenticationScheme, accessToken);
+            request.Content = content;
+            return _client.SendAsync(request);
+        }
+
         private Task<HttpResponseMessage> PerformGetRequestAsync(string path)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, path);
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> PostDataAsync(string path, string userAccessToken, StringContent content)
+        private static void SetAuthenticationHeader(HttpRequestMessage request, string authenticationScheme, string accessToken)
         {
-            throw new NotImplementedException();
+            if (string.IsNullOrEmpty(authenticationScheme) || string.IsNullOrEmpty(accessToken)) return;
+            request.Headers.Authorization = new AuthenticationHeaderValue(authenticationScheme, accessToken);
         }
 
-        public Task<HttpResponseMessage> PutDataAsync(string path, string userAccessToken, StringContent content)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<HttpResponseMessage> DeleteAsync(string path, string userAccessToken, StringContent content)
-        {
-            throw new NotImplementedException();
-        }
     }
 }

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -76,5 +76,20 @@ namespace Nrk.HttpRequester
             var request = new HttpRequestMessage(HttpMethod.Get, path);
             return _client.SendAsync(request);
         }
+
+        public Task<HttpResponseMessage> PostDataAsync(string path, string userAccessToken, StringContent content)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<HttpResponseMessage> PutDataAsync(string path, string userAccessToken, StringContent content)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<HttpResponseMessage> DeleteAsync(string path, string userAccessToken, StringContent content)
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
Added methods to IWebRequester to perform HTTP Delete, Put and Post with authorization header.

Need to update readme with documentation for the new methods.
