### PR TITLE
Sketching out a solution for retry with different timeouts (do not merge..)

### DIFF
--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
+using System.Threading.Tasks;
 using Nancy;
 using Nancy.Extensions;
 using Owin;
@@ -31,10 +33,10 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
             
             Delete["/content"] = _ => Request.Body.AsString();
 
-            Get["/delay/{ms:int}"] = parameters =>
+            Get["/delay/{ms:int}", true] = async (parameters, ct) =>
             {
-                Thread.Sleep(parameters.ms);
-                return $"Finished sleeping for {parameters.ms}ms";
+                await Task.Delay(TimeSpan.FromMilliseconds(parameters.ms));
+                return (Response)$"Finished waiting for {parameters.ms}ms";
             };
 
             Get["/headers"] = _ =>

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -52,8 +52,8 @@ namespace Nrk.HttpRequester.IntegrationTests
             var response = await webRequester.GetResponseAsync("/delay/150", new List<TimeSpan>
             {
                 TimeSpan.FromMilliseconds(101),
-                TimeSpan.FromMilliseconds(201),
-                TimeSpan.FromMilliseconds(1550)
+                TimeSpan.FromMilliseconds(140),
+                TimeSpan.FromMilliseconds(350)
             });
 
             // Assert

--- a/source/Nrk.HttpRequester/IHttpClient.cs
+++ b/source/Nrk.HttpRequester/IHttpClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nrk.HttpRequester
@@ -7,5 +8,6 @@ namespace Nrk.HttpRequester
     {
         HttpClient Client { get; }
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
+        Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken);
     }
 }

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
@@ -10,6 +13,7 @@ namespace Nrk.HttpRequester
         Task<string> GetResponseAsStringAsync(string path, int retries = 0);
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
+        Task<HttpResponseMessage> GetResponseAsync(string path, IList<TimeSpan> retries);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content);

--- a/source/Nrk.HttpRequester/WebRequestHttpClientFactory.cs
+++ b/source/Nrk.HttpRequester/WebRequestHttpClientFactory.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Nrk.HttpRequester
@@ -58,7 +59,7 @@ namespace Nrk.HttpRequester
 
                 _baseUrl = baseUrl;
             }
-
+            
             public IHttpClientBuilder WithTimeout(TimeSpan timeout)
             {
                 _timeout = timeout;
@@ -148,6 +149,12 @@ namespace Nrk.HttpRequester
             public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
             {
                 return Client.SendAsync(request);
+            }
+
+            public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+            {
+
+                return Client.SendAsync(request, completionOption, cancellationToken);
             }
         }
     }

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -65,6 +67,7 @@ namespace Nrk.HttpRequester
         }
         public Task<HttpResponseMessage> GetResponseAsync(string path, IList<TimeSpan> retries)
         {
+            Debug.Assert(retries.All(r => r < _client.Client.Timeout), "Does not make sense with longer timeouts");
             var urlWithParameters = UriBuilder.Build(path, _defaultQueryParameters);
             var retryQueue = new Queue<TimeSpan>(retries);
             var delay = retryQueue.Dequeue();


### PR DESCRIPTION
Tried to find a way to address https://github.com/nrkno/Nrk.HttpRequester/issues/8

I think it would be better to actually stop using the HttpClient Timeout for retry-timeouts (I mean, it could still be possible to set it, but it must be made clear that it is not meant to be used as a short timeout for a specific route, as it will be used globally, even if longer timeouts are set on SendAsync ) 

This will probably require a version 2 of the library.