### PR TITLE
Add auth header overloads to Get requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@
   branches:
     only:
       - master
-  version: 1.0.{build}
+  version: 1.1.{build}
   build_script:
     build.cmd version=%APPVEYOR_BUILD_VERSION%
   test: off

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nrk.HttpRequester.IntegrationTests.TestServer;
 using Shouldly;
 using Xunit;
@@ -61,6 +62,33 @@ namespace Nrk.HttpRequester.IntegrationTests
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
+        }
+
+        [Fact]
+        public async Task GetResponseAsync_ShouldSetAuthorizationHeader()
+        {
+            // Arrange
+            const string authorizationScheme = "bearer";
+            const string accessToken = "accessToken";
+            // Act
+            var response = await _webRequester.GetResponseAsync("/headers", new AuthenticationHeaderValue(authorizationScheme, accessToken));
+
+            // Assert
+            VerifyAuthorizationHeader(response, authorizationScheme, accessToken);
+        }
+
+        [Fact]
+        public async Task GetResponseAsStringAsync_ShouldSetAuthorizationHeader()
+        {
+            // Arrange
+            const string authorizationScheme = "bearer";
+            const string accessToken = "accessToken";
+            // Act
+            var response = await _webRequester.GetResponseAsStringAsync("/headers", new AuthenticationHeaderValue(authorizationScheme, accessToken));
+
+            // Assert
+            response.ShouldContain("Authorization");
+            response.ShouldContain("bearer accessToken");
         }
 
         [Fact]

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -12,7 +12,6 @@ namespace Nrk.HttpRequester.UnitTests
     {
         private readonly HttpResponseMessage _basicResponse;
         private readonly HttpClient _basicClient;
-        private Uri _baseAdress;
 
         public WebRequesterTests()
         {
@@ -20,7 +19,6 @@ namespace Nrk.HttpRequester.UnitTests
             var client = new HttpClient { BaseAddress = baseAdress };
 
             _basicClient = client;
-            _baseAdress = baseAdress;
             _basicResponse = new HttpResponseMessage
             {
                 Content = new StringContent("All good")
@@ -107,7 +105,7 @@ namespace Nrk.HttpRequester.UnitTests
             var requester = new WebRequester(httpClient);
 
             // Act
-            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsync("/test", null, 0); });
+            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsync("/test", null, null, 0); });
 
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();
@@ -121,7 +119,7 @@ namespace Nrk.HttpRequester.UnitTests
             var requester = new WebRequester(httpClient);
 
             // Act
-            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsStringAsync("/test", null, 0); });
+            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsStringAsync("/test", null, null, 0); });
 
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();

--- a/source/Nrk.HttpRequester.sln
+++ b/source/Nrk.HttpRequester.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.9
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nrk.HttpRequester", "Nrk.HttpRequester\Nrk.HttpRequester.csproj", "{372CFF1E-9336-4E40-8648-0B96C54687D1}"
 EndProject
@@ -9,7 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nrk.HttpRequester.UnitTests
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{879D3C33-C945-47AD-8C16-0624E8EFA5F1}"
 	ProjectSection(SolutionItems) = preProject
-		appveyor.yml = appveyor.yml
+		..\appveyor.yml = ..\appveyor.yml
 		..\build.cmd = ..\build.cmd
 		..\build.fsx = ..\build.fsx
 	EndProjectSection

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -7,9 +7,13 @@ namespace Nrk.HttpRequester
 {
     public interface IWebRequester
     {
+        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
         Task<string> GetResponseAsStringAsync(string path, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
         Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
+        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
+	    Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content);

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -27,6 +27,22 @@ namespace Nrk.HttpRequester
             _defaultQueryParameters = new NameValueCollection();
         }
 
+        public Task<string> GetResponseAsStringAsync(
+            string pathTemplate,
+            NameValueCollection parameters,
+            AuthenticationHeaderValue authenticationHeader,
+            int retries = 0)
+        {
+	        if (parameters == null)
+	        {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            var uri = UriBuilder.Build(pathTemplate, parameters);
+
+            return GetResponseAsStringAsync(uri, retries);
+        }
+
         public Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0)
         {
             if (parameters == null)
@@ -39,6 +55,19 @@ namespace Nrk.HttpRequester
             return GetResponseAsStringAsync(uri, retries);
         }
 
+
+        public async Task<string> GetResponseAsStringAsync(
+            string path,
+            AuthenticationHeaderValue authenticationHeader,
+            int retries = 0)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, path);
+	        request.Headers.Authorization = authenticationHeader;
+
+	        var response = await _client.SendAsync(request).ConfigureAwait(false);
+	        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
         public async Task<string> GetResponseAsStringAsync(string path, int retries = 0)
         {
             var response = await GetResponseAsync(path, retries).ConfigureAwait(false);
@@ -48,6 +77,26 @@ namespace Nrk.HttpRequester
             }
 
             return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        }
+
+
+        public Task<HttpResponseMessage> GetResponseAsync(
+            string pathTemplate,
+            NameValueCollection parameters,
+            AuthenticationHeaderValue authenticationHeader,
+            int retries = 0)
+        {
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            var uri = UriBuilder.Build(pathTemplate, parameters);
+
+            var request = new HttpRequestMessage(HttpMethod.Get, uri);
+	        request.Headers.Authorization = authenticationHeader;
+
+	        return _client.SendAsync(request);
         }
 
         public Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0)
@@ -62,6 +111,17 @@ namespace Nrk.HttpRequester
             return GetResponseAsync(url, retries);
         }
 
+        public Task<HttpResponseMessage> GetResponseAsync(
+            string path,
+            AuthenticationHeaderValue authenticationHeader,
+            int retries = 0)
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, path);
+	        request.Headers.Authorization = authenticationHeader;
+
+	        return _client.SendAsync(request);
+        }
+
         public Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0)
         {
             var urlWithParameters = UriBuilder.Build(path, _defaultQueryParameters);
@@ -72,7 +132,10 @@ namespace Nrk.HttpRequester
             return requestPolicy.ExecuteAsync(() => PerformGetRequestAsync(urlWithParameters));
         }
 
-        public Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader)
+        public Task<HttpResponseMessage> PostAsync(
+            string path,
+            StringContent content,
+            AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Post, path);
             request.Headers.Authorization = authenticationHeader;
@@ -90,7 +153,10 @@ namespace Nrk.HttpRequester
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> PutAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader)
+        public Task<HttpResponseMessage> PutAsync(
+            string path,
+            StringContent content,
+            AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Put, path);
             request.Headers.Authorization = authenticationHeader;
@@ -108,7 +174,10 @@ namespace Nrk.HttpRequester
             return _client.SendAsync(request);
         }
 
-        public Task<HttpResponseMessage> DeleteAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader)
+        public Task<HttpResponseMessage> DeleteAsync(
+            string path,
+            StringContent content,
+            AuthenticationHeaderValue authenticationHeader)
         {
             var request = new HttpRequestMessage(HttpMethod.Delete, path);
             request.Headers.Authorization = authenticationHeader;
@@ -138,7 +207,7 @@ namespace Nrk.HttpRequester
             var request = new HttpRequestMessage(HttpMethod.Put, path);
             return _client.SendAsync(request);
         }
-      
+
         public Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request)
         {
             return _client.SendAsync(request);


### PR DESCRIPTION
Get requests methods will also need a way to add authentication headers.

- [x] Add AuthenticationHeaderValue parameter for the different Get methods.
- [x] Add integration tests to verify headers are being sent correctly.
