### PR TITLE
Fix default query parameters

### DIFF
--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -95,7 +95,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PutAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.PutAsync("", new StringContent("test"));
+            var response = await _webRequester.PutAsync("/", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -132,7 +132,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task PostAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.PostAsync("", new StringContent("test"));
+            var response = await _webRequester.PostAsync("/", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();
@@ -169,7 +169,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task DeleteAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.DeleteAsync("", new StringContent("test"));
+            var response = await _webRequester.DeleteAsync("/", new StringContent("test"));
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -58,7 +58,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         public async Task GetResponseAsync_ShouldGetResponseFromServer()
         {
             // Act
-            var response = await _webRequester.GetResponseAsync("");
+            var response = await _webRequester.GetResponseAsync("/");
 
             // Assert
             response.IsSuccessStatusCode.ShouldBeTrue();

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -247,6 +247,37 @@ namespace Nrk.HttpRequester.UnitTests
         }
 
         [Fact]
+        public async Task Send_WithUrlAndDefaultParameters_ShouldBuildCorrectUrl()
+        {
+            // Arrange
+            var httpClient = A.Fake<IHttpClient>();
+            var url = "test/itemName/123";
+            var defaultParams = new NameValueCollection { { "APIKey", "keyvalue" } };
+            var expectedUrl = "/test/itemName/123?APIKey=keyvalue";
+            A.CallTo(
+                    () =>
+                        httpClient.SendAsync(
+                            A<HttpRequestMessage>.Ignored))
+                .Returns(_basicResponse);
+            A.CallTo(
+                    () =>
+                        httpClient.Client)
+                .Returns(_basicClient);
+            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1), defaultParams);
+
+            // Act
+            var request = new HttpRequestMessage(HttpMethod.Get, url);
+            await requester.SendMessageAsyncWithRetries(request, 0);
+
+            // Assert
+            A.CallTo(
+                () =>
+                    httpClient.SendAsync(
+                        A<HttpRequestMessage>.That.Matches(req => req.RequestUri.ToString().Equals(expectedUrl)))
+            ).MustHaveHappened();
+        }
+
+        [Fact]
         public async Task GetResponseAsync_WithQueryParameterAndDefaultParameters_ShouldAppendDefaultParameters()
         {
             // Arrange

--- a/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
@@ -5,20 +5,20 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitleAttribute("NRK.HttpRequester")]
 [assembly: AssemblyProductAttribute("NRK.HttpRequester")]
 [assembly: AssemblyDescriptionAttribute("Library for sending Http Requests, including a fluent interface for creating HttpClient instances")]
-[assembly: AssemblyVersionAttribute("1.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("1.0.0")]
-[assembly: AssemblyFileVersionAttribute("1.0.0")]
+[assembly: AssemblyVersionAttribute("0.0.0")]
+[assembly: AssemblyInformationalVersionAttribute("0.0.0")]
+[assembly: AssemblyFileVersionAttribute("0.0.0")]
 [assembly: GuidAttribute("d51e7a23-73d5-49a1-be63-f73e432e9ab3")]
-[assembly: AssemblyMetadataAttribute("githash","df607ccdd20d7d6946fc93bc382c4734a81a3be5")]
+[assembly: AssemblyMetadataAttribute("githash","60890f4fee57fb30a3ca57260b4589b69ac40701")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "NRK.HttpRequester";
         internal const System.String AssemblyProduct = "NRK.HttpRequester";
         internal const System.String AssemblyDescription = "Library for sending Http Requests, including a fluent interface for creating HttpClient instances";
-        internal const System.String AssemblyVersion = "1.0.0";
-        internal const System.String AssemblyInformationalVersion = "1.0.0";
-        internal const System.String AssemblyFileVersion = "1.0.0";
+        internal const System.String AssemblyVersion = "0.0.0";
+        internal const System.String AssemblyInformationalVersion = "0.0.0";
+        internal const System.String AssemblyFileVersion = "0.0.0";
         internal const System.String Guid = "d51e7a23-73d5-49a1-be63-f73e432e9ab3";
-        internal const System.String AssemblyMetadata_githash = "df607ccdd20d7d6946fc93bc382c4734a81a3be5";
+        internal const System.String AssemblyMetadata_githash = "60890f4fee57fb30a3ca57260b4589b69ac40701";
     }
 }

--- a/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
@@ -5,20 +5,20 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitleAttribute("NRK.HttpRequester")]
 [assembly: AssemblyProductAttribute("NRK.HttpRequester")]
 [assembly: AssemblyDescriptionAttribute("Library for sending Http Requests, including a fluent interface for creating HttpClient instances")]
-[assembly: AssemblyVersionAttribute("0.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("0.0.0")]
-[assembly: AssemblyFileVersionAttribute("0.0.0")]
+[assembly: AssemblyVersionAttribute("1.0.0")]
+[assembly: AssemblyInformationalVersionAttribute("1.0.0")]
+[assembly: AssemblyFileVersionAttribute("1.0.0")]
 [assembly: GuidAttribute("d51e7a23-73d5-49a1-be63-f73e432e9ab3")]
-[assembly: AssemblyMetadataAttribute("githash","60890f4fee57fb30a3ca57260b4589b69ac40701")]
+[assembly: AssemblyMetadataAttribute("githash","df607ccdd20d7d6946fc93bc382c4734a81a3be5")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "NRK.HttpRequester";
         internal const System.String AssemblyProduct = "NRK.HttpRequester";
         internal const System.String AssemblyDescription = "Library for sending Http Requests, including a fluent interface for creating HttpClient instances";
-        internal const System.String AssemblyVersion = "0.0.0";
-        internal const System.String AssemblyInformationalVersion = "0.0.0";
-        internal const System.String AssemblyFileVersion = "0.0.0";
+        internal const System.String AssemblyVersion = "1.0.0";
+        internal const System.String AssemblyInformationalVersion = "1.0.0";
+        internal const System.String AssemblyFileVersion = "1.0.0";
         internal const System.String Guid = "d51e7a23-73d5-49a1-be63-f73e432e9ab3";
-        internal const System.String AssemblyMetadata_githash = "60890f4fee57fb30a3ca57260b4589b69ac40701";
+        internal const System.String AssemblyMetadata_githash = "df607ccdd20d7d6946fc93bc382c4734a81a3be5";
     }
 }

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -33,8 +33,8 @@ namespace Nrk.HttpRequester
             AuthenticationHeaderValue authenticationHeader,
             int retries = 0)
         {
-	        if (parameters == null)
-	        {
+            if (parameters == null)
+            {
                 throw new ArgumentNullException(nameof(parameters));
             }
 
@@ -62,10 +62,10 @@ namespace Nrk.HttpRequester
             int retries = 0)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, path);
-	        request.Headers.Authorization = authenticationHeader;
+            request.Headers.Authorization = authenticationHeader;
 
-	        var response = await SendMessageAsync(request).ConfigureAwait(false);
-	        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var response = await SendMessageAsync(request).ConfigureAwait(false);
+            return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }
 
         public async Task<string> GetResponseAsStringAsync(string path, int retries = 0)
@@ -94,9 +94,9 @@ namespace Nrk.HttpRequester
             var uri = UriBuilder.Build(pathTemplate, parameters);
 
             var request = new HttpRequestMessage(HttpMethod.Get, uri);
-	        request.Headers.Authorization = authenticationHeader;
+            request.Headers.Authorization = authenticationHeader;
 
-	        return SendMessageAsync(request);
+            return SendMessageAsync(request);
         }
 
         public Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0)
@@ -117,9 +117,9 @@ namespace Nrk.HttpRequester
             int retries = 0)
         {
             var request = new HttpRequestMessage(HttpMethod.Get, path);
-	        request.Headers.Authorization = authenticationHeader;
+            request.Headers.Authorization = authenticationHeader;
 
-	        return SendMessageAsync(request);
+            return SendMessageAsync(request);
         }
 
         public Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0)
@@ -209,7 +209,7 @@ namespace Nrk.HttpRequester
 
         public Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request)
         {
-	        AddDefaultQueryParameters(request);
+            AddDefaultQueryParameters(request);
             return _client.SendAsync(request);
         }
 
@@ -230,12 +230,12 @@ namespace Nrk.HttpRequester
             return _client.SendAsync(request);
         }
 
-	    private void AddDefaultQueryParameters(HttpRequestMessage request)
-	    {
-		    var currentUri = request.RequestUri;
-		    var path = currentUri.IsAbsoluteUri ? currentUri.PathAndQuery : currentUri.ToString();
+        private void AddDefaultQueryParameters(HttpRequestMessage request)
+        {
+            var currentUri = request.RequestUri;
+            var path = currentUri.IsAbsoluteUri ? currentUri.PathAndQuery : currentUri.ToString();
             var pathWithDefaultQueryParameters = UriBuilder.Build(path, _defaultQueryParameters);
             request.RequestUri = new Uri(pathWithDefaultQueryParameters, UriKind.Relative);
-	    }
+        }
     }
 }

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -17,7 +17,7 @@ namespace Nrk.HttpRequester
         {
             _client = client;
             _retryTimeout = retryTimeout;
-            _defaultQueryParameters = defaultQueryParameters ?? new NameValueCollection{ {"lol", "hey"}};
+            _defaultQueryParameters = defaultQueryParameters ?? new NameValueCollection();
         }
 
         public WebRequester(IHttpClient client)


### PR DESCRIPTION
Default query parameters were not added to all requests sent, only a few of the Get methods.