### PR TITLE
Clean empty parameters for UriBuilding

### DIFF
--- a/source/Nrk.HttpRequester.UnitTests/Nrk.HttpRequester.UnitTests.csproj
+++ b/source/Nrk.HttpRequester.UnitTests/Nrk.HttpRequester.UnitTests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -69,6 +70,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="UriBuilderTests.cs" />
     <Compile Include="WebRequesterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebRequestHttpClientFactoryTests.cs" />
@@ -103,6 +105,12 @@
   </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/source/Nrk.HttpRequester.UnitTests/UriBuilderTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/UriBuilderTests.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Shouldly;
+using Xunit;
+
+namespace Nrk.HttpRequester.UnitTests
+{
+    public class UriBuilderTests
+    {
+        [Fact]
+        public void Build_GivenNoParameters_ShouldReturnTemplatePath()
+        {
+            var template = "test/path";
+
+            var path = UriBuilder.Build(template, new NameValueCollection());
+
+            path.ShouldBe("/test/path");
+        }
+
+        [Fact]
+        public void Build_GivenParameterWithNullValue_ShouldIgnoreEmptyParameter()
+        {
+            var template = "test/path";
+            var parameters = new NameValueCollection { {"validSet", "value"}, {"invalidSet", null}};
+
+            var path = UriBuilder.Build(template,parameters);
+
+            path.ShouldBe("/test/path?validSet=value");
+        }
+
+        [Fact]
+        public void Build_GivenParameterWithValue_ShouldGenerateCorrectPath()
+        {
+            var template = "test/{path}";
+            var parameters = new NameValueCollection { { "path", "1234" }, { "invalidSet", null }, { "query", "parameter" } };
+
+            var path = UriBuilder.Build(template, parameters);
+
+            path.ShouldBe("/test/1234?query=parameter");
+        }
+    }
+}

--- a/source/Nrk.HttpRequester.UnitTests/packages.config
+++ b/source/Nrk.HttpRequester.UnitTests/packages.config
@@ -5,4 +5,5 @@
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
   <package id="xunit.extensibility.execution" version="2.0.0" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/source/Nrk.HttpRequester/UriBuilder.cs
+++ b/source/Nrk.HttpRequester/UriBuilder.cs
@@ -3,16 +3,24 @@ using System.Collections.Specialized;
 
 namespace Nrk.HttpRequester
 {
-    internal static class UriBuilder
+    public static class UriBuilder
     {
-        internal static string Build(string template, NameValueCollection parameters)
+        public static string Build(string template, NameValueCollection parameters)
         {
             var uriTemplate = new UriTemplate(template);
 
             // Base URI is set in the HttpClient, this one is just needed for binding
             var prefix = new Uri("http://localhost");
 
-            var uri = uriTemplate.BindByName(prefix, parameters);
+            var noEmptyParametersCollection = new NameValueCollection();
+            foreach (string name in parameters)
+            {
+                var value = parameters[name];
+                if (!string.IsNullOrEmpty(value))
+                    noEmptyParametersCollection.Add(name, value);
+            }
+
+            var uri = uriTemplate.BindByName(prefix, noEmptyParametersCollection);
             return uri.PathAndQuery;
         }
     }


### PR DESCRIPTION
UriTemplateBinding will add null values as empty query parameters to the path. `new NameValueCollection { { "invalidParameter" , null}, { "valid", "parameter"} }` will be added as `?invalidParameter=&valid=parameter`, potentially leading to bad request responses.