### PR TITLE
Child friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ The recommended usage of HttpClient is not to dispose it after every request. It
 A re-usable HttpClient introduces the risk of not honoring DNS changes. We try to fix this by setting the `ConnectionLeaseTimeout` for the Service Endpoint, which is by default infinite.
 
 ## Usage
-First build an IHttpClient. The fluent interface allows you to set Timeout, DefaultRequestheaders, DelegatingHandler and DelegatingHandlers for caching.:
+### Build an IHttpClient
+The fluent interface allows you to set Timeout, DefaultRequestheaders, DelegatingHandler and DelegatingHandlers for caching.:
 ```cs
 var httpClient = WebRequestHttpClientFactory
     .Configure(new Uri("www.yourBaseUrl.com"))
@@ -20,19 +21,17 @@ var httpClient = WebRequestHttpClientFactory
     .WithConnectionLeaseTimeout(60000)
     .Create();
 ```
-
-Next, new up the WebRequester:
+### New up a `WebRequester`
 ```cs
 var webRequester = new WebRequester(httpClient);
 ```
 
-The WebRequester is an immutable object. If you need a version which adds specific info on outgoing requests, this can be done with the `With(Action<HttpRequestMessage> message)` method. This returns a copy of the requester with the same configuration (including `IHttpClient`), except it may add a header, like this:
-
+`WebRequester` is an immutable object. If you need a modified version, this can be done with the `With(Action<HttpRequestMessage> message)` method. E.g:
 ```cs
 var webRequester = new WebRequester(httpClient);
 var childRequester = webRequester.With(m => m.Headers.Add("request-specific-header", "request-specific value"));
 ```
-
+`childRequester` is a copy of `webRequester` with the same configuration (including `IHttpClient`), except it adds a "request-specific-header" to every outgoing request. This is useful for request-ids and request correlation.
 
 
 The following methods are available from IWebRequester:
@@ -44,6 +43,7 @@ The following methods are available from IWebRequester:
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
 ```
 
+### Use the `WebRequester`
 You can either send a path `example/path/123` or a [URI Template](https://tools.ietf.org/html/rfc6570) string with matching parameters in a [`NameValueCollection`](https://msdn.microsoft.com/en-us/library/system.collections.specialized.namevaluecollection(v=vs.110).aspx):
 
 ```cs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ var httpClient = WebRequestHttpClientFactory
     .WithConnectionLeaseTimeout(60000)
     .Create();
 ```
-### New up a `WebRequester`
+### New up a WebRequester
 ```cs
 var webRequester = new WebRequester(httpClient);
 ```
@@ -34,6 +34,9 @@ var childRequester = webRequester.With(m => m.Headers.Add("request-specific-head
 `childRequester` is a copy of `webRequester` with the same configuration (including `IHttpClient`), except it adds a "request-specific-header" to every outgoing request. This is useful for request-ids and request correlation.
 
 
+
+
+### Use the WebRequester
 The following methods are available from IWebRequester:
 
 ```cs
@@ -43,7 +46,6 @@ The following methods are available from IWebRequester:
         Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
 ```
 
-### Use the `WebRequester`
 You can either send a path `example/path/123` or a [URI Template](https://tools.ietf.org/html/rfc6570) string with matching parameters in a [`NameValueCollection`](https://msdn.microsoft.com/en-us/library/system.collections.specialized.namevaluecollection(v=vs.110).aspx):
 
 ```cs

--- a/README.md
+++ b/README.md
@@ -11,24 +11,29 @@ The recommended usage of HttpClient is not to dispose it after every request. It
 A re-usable HttpClient introduces the risk of not honoring DNS changes. We try to fix this by setting the `ConnectionLeaseTimeout` for the Service Endpoint, which is by default infinite.
 
 ## Usage
-Set up WebRequester with baseUrl:
+First build an IHttpClient. The fluent interface allows you to set Timeout, DefaultRequestheaders, DelegatingHandler and DelegatingHandlers for caching.:
 ```cs
 var httpClient = WebRequestHttpClientFactory
     .Configure(new Uri("www.yourBaseUrl.com"))
-    .Create()
-var webRequester = new WebRequester(httpClient);
-```
-The WebRequestHttpClientFactory uses a fluent interface, which can be used to set Timeout, DefaultRequestheaders, DelegatingHandler and DelegatingHandlers for caching.
-
-```cs
-var httpClient = WebRequestHttpClientFactory
-    .Configure(new Uri("www.yourBaseUrl.com"))
-    .WithDefaultRequestHeaders(new Dictionary<string, string> {{"header", "value"}})
+    .WithDefaultRequestHeaders(new Dictionary<string, string> {{"header", "value"}}) // added to all requests
     .WithHandler(yourHandler)
     .WithConnectionLeaseTimeout(60000)
-    .Create()
+    .Create();
+```
+
+Next, new up the WebRequester:
+```cs
 var webRequester = new WebRequester(httpClient);
 ```
+
+The WebRequester is an immutable object. If you need a version which adds specific info on outgoing requests, this can be done with the `With(Action<HttpRequestMessage> message)` method. This returns a copy of the requester with the same configuration (including `IHttpClient`), except it may add a header, like this:
+
+```cs
+var webRequester = new WebRequester(httpClient);
+var childRequester = webRequester.With(m => m.Headers.Add("request-specific-header", "request-specific value"));
+```
+
+
 
 The following methods are available from IWebRequester:
 

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -45,18 +45,18 @@ namespace Nrk.HttpRequester
             {
                 throw new ArgumentNullException(nameof(requestModifier));
             }
-            return CopyWith(beforeRequestActions: _requestModifiers.Concat(new[] {requestModifier}));
+            return CopyWith(requestModifiers: _requestModifiers.Concat(new[] {requestModifier}));
         }
 
         private WebRequester CopyWith(IHttpClient client = null, TimeSpan? retryTimeout = null,
             NameValueCollection defaultqueryParameters = null,
-            IEnumerable<Action<HttpRequestMessage>> beforeRequestActions = null)
+            IEnumerable<Action<HttpRequestMessage>> requestModifiers = null)
         {
             return new WebRequester(
                 client ?? _client,
                 retryTimeout ?? _retryTimeout,
                 defaultqueryParameters ?? _defaultQueryParameters,
-                beforeRequestActions ?? _requestModifiers
+                requestModifiers ?? _requestModifiers
                 );
         }
 

--- a/source/Nrk.HttpRequester/WebRequester.cs
+++ b/source/Nrk.HttpRequester/WebRequester.cs
@@ -14,7 +14,7 @@ namespace Nrk.HttpRequester
         private readonly IHttpClient _client;
         private readonly TimeSpan _retryTimeout;
         private readonly NameValueCollection _defaultQueryParameters;
-        private readonly IList<Action<HttpRequestMessage>> _requestModifiers = new List<Action<HttpRequestMessage>>();
+        private readonly IList<Action<HttpRequestMessage>> _requestModifiers;
 
         public WebRequester(IHttpClient client,
             TimeSpan? retryTimeout = null,
@@ -27,11 +27,16 @@ namespace Nrk.HttpRequester
             _requestModifiers = beforeRequestActions?.ToList() ?? new List<Action<HttpRequestMessage>>();
         }
 
-        public WebRequester(IHttpClient client)
+        private WebRequester CopyWith(IHttpClient client = null, TimeSpan? retryTimeout = null,
+            NameValueCollection defaultqueryParameters = null,
+            IEnumerable<Action<HttpRequestMessage>> requestModifiers = null)
         {
-            _client = client;
-            _retryTimeout = TimeSpan.FromSeconds(3);
-            _defaultQueryParameters = new NameValueCollection();
+            return new WebRequester(
+                client ?? _client,
+                retryTimeout ?? _retryTimeout,
+                defaultqueryParameters ?? _defaultQueryParameters,
+                requestModifiers ?? _requestModifiers
+            );
         }
 
         /// <summary>
@@ -46,18 +51,6 @@ namespace Nrk.HttpRequester
                 throw new ArgumentNullException(nameof(requestModifier));
             }
             return CopyWith(requestModifiers: _requestModifiers.Concat(new[] {requestModifier}));
-        }
-
-        private WebRequester CopyWith(IHttpClient client = null, TimeSpan? retryTimeout = null,
-            NameValueCollection defaultqueryParameters = null,
-            IEnumerable<Action<HttpRequestMessage>> requestModifiers = null)
-        {
-            return new WebRequester(
-                client ?? _client,
-                retryTimeout ?? _retryTimeout,
-                defaultqueryParameters ?? _defaultQueryParameters,
-                requestModifiers ?? _requestModifiers
-                );
         }
 
         public Task<string> GetResponseAsStringAsync(


### PR DESCRIPTION
Support for additional actions (request-modifiers) before sending request.

public WebRequester With(Action<HttpRequestMessage> requestModifier) returns an immutable copy of this WebRequester, with an additional requestModifier.

var newRequeseter = existingRequester.With(m => m.Headers["some-header"] = "some value");

The new Requester will add "some-header" to every request.