### PR TITLE
User agent

### DIFF
--- a/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
+++ b/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
@@ -92,6 +92,7 @@
     </Otherwise>
   </Choose>
   <ItemGroup>
+    <Compile Include="TestData\Some.cs" />
     <Compile Include="TestServer\Server.cs" />
     <Compile Include="WebRequesterIntegrationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/Nrk.HttpRequester.IntegrationTests/TestData/Some.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestData/Some.cs
@@ -2,7 +2,7 @@
 {
     public static class Some
     {
-        public const string Product = "Application";
+        public const string Product = "MyApplication";
         public const string Version = "1.0.0";
         public static readonly UserAgent UserAgent = new UserAgent(Product, Version);
     }

--- a/source/Nrk.HttpRequester.IntegrationTests/TestData/Some.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestData/Some.cs
@@ -1,0 +1,9 @@
+﻿namespace Nrk.HttpRequester.IntegrationTests.TestData
+{
+    public static class Some
+    {
+        public const string Product = "Application";
+        public const string Version = "1.0.0";
+        public static readonly UserAgent UserAgent = new UserAgent(Product, Version);
+    }
+}

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -4,7 +4,6 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
-using Nrk.HttpRequester.IntegrationTests.TestData;
 using Nrk.HttpRequester.IntegrationTests.TestServer;
 using Shouldly;
 using Xunit;
@@ -20,14 +19,14 @@ namespace Nrk.HttpRequester.IntegrationTests
         public WebRequesterIntegrationTests()
         {
             _webApp = WebApp.Start<Startup>(Url);
-            _webRequester = new WebRequester(WebRequestHttpClientFactory.Configure(new Uri(Url), Some.UserAgent).Create());
+            _webRequester = new WebRequester(WebRequestHttpClientFactory.Configure(new Uri(Url)).Create());
         }
 
         [Fact]
         public async Task GetResponseAsync_ShouldTimeoutOnSlowResponse()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url), Some.UserAgent).WithTimeout(TimeSpan.FromMilliseconds(100)).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).WithTimeout(TimeSpan.FromMilliseconds(100)).Create();
             var webRequester = new WebRequester(httpClient);
 
             // Act
@@ -42,7 +41,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         {
             // Arrange
             var httpClient =
-                WebRequestHttpClientFactory.Configure(new Uri(Url), Some.UserAgent)
+                WebRequestHttpClientFactory.Configure(new Uri(Url))
                     .WithDefaultRequestHeaders(new Dictionary<string, string> { { "fakeHeader", "fakeValue" } })
                     .Create();
             var webRequester = new WebRequester(httpClient);

--- a/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/WebRequesterIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Owin.Hosting;
+using Nrk.HttpRequester.IntegrationTests.TestData;
 using Nrk.HttpRequester.IntegrationTests.TestServer;
 using Shouldly;
 using Xunit;
@@ -19,14 +20,14 @@ namespace Nrk.HttpRequester.IntegrationTests
         public WebRequesterIntegrationTests()
         {
             _webApp = WebApp.Start<Startup>(Url);
-            _webRequester = new WebRequester(WebRequestHttpClientFactory.Configure(new Uri(Url)).Create());
+            _webRequester = new WebRequester(WebRequestHttpClientFactory.Configure(new Uri(Url), Some.UserAgent).Create());
         }
 
         [Fact]
         public async Task GetResponseAsync_ShouldTimeoutOnSlowResponse()
         {
             // Arrange
-            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url)).WithTimeout(TimeSpan.FromMilliseconds(100)).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(new Uri(Url), Some.UserAgent).WithTimeout(TimeSpan.FromMilliseconds(100)).Create();
             var webRequester = new WebRequester(httpClient);
 
             // Act
@@ -41,7 +42,7 @@ namespace Nrk.HttpRequester.IntegrationTests
         {
             // Arrange
             var httpClient =
-                WebRequestHttpClientFactory.Configure(new Uri(Url))
+                WebRequestHttpClientFactory.Configure(new Uri(Url), Some.UserAgent)
                     .WithDefaultRequestHeaders(new Dictionary<string, string> { { "fakeHeader", "fakeValue" } })
                     .Create();
             var webRequester = new WebRequester(httpClient);

--- a/source/Nrk.HttpRequester.UnitTests/Nrk.HttpRequester.UnitTests.csproj
+++ b/source/Nrk.HttpRequester.UnitTests/Nrk.HttpRequester.UnitTests.csproj
@@ -70,7 +70,9 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="TestData\Some.cs" />
     <Compile Include="UriBuilderTests.cs" />
+    <Compile Include="UserAgentTest.cs" />
     <Compile Include="WebRequesterTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WebRequestHttpClientFactoryTests.cs" />

--- a/source/Nrk.HttpRequester.UnitTests/TestData/Some.cs
+++ b/source/Nrk.HttpRequester.UnitTests/TestData/Some.cs
@@ -12,5 +12,6 @@ namespace Nrk.HttpRequester.UnitTests.TestData
 
         public static readonly UserAgent UserAgent = new UserAgent(Product, Version);
         public static readonly Uri Uri = new Uri("https://some.host");
+        public const string Framework = "MyFramework";
     }
 }

--- a/source/Nrk.HttpRequester.UnitTests/TestData/Some.cs
+++ b/source/Nrk.HttpRequester.UnitTests/TestData/Some.cs
@@ -4,13 +4,13 @@ namespace Nrk.HttpRequester.UnitTests.TestData
 {
     public static class Some
     {
-        public const string Product = "Application";
+        public const string Product = "MyApplication";
         public const string Version = "1.0.0";
         public const string Comment = "This is a comment";
-        public const string DataCenter = "Azure-WE";
-        public const string MachineName = "MachineName";
+        public const string DataCenter = "MyDatacenter";
+        public const string MachineName = "MyMachineName";
 
         public static readonly UserAgent UserAgent = new UserAgent(Product, Version);
-        public static readonly Uri Uri = new Uri("https://pølse.med.lompe");
+        public static readonly Uri Uri = new Uri("https://some.host");
     }
 }

--- a/source/Nrk.HttpRequester.UnitTests/TestData/Some.cs
+++ b/source/Nrk.HttpRequester.UnitTests/TestData/Some.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Nrk.HttpRequester.UnitTests.TestData
+{
+    public static class Some
+    {
+        public const string Product = "Application";
+        public const string Version = "1.0.0";
+        public const string Comment = "This is a comment";
+        public const string DataCenter = "Azure-WE";
+        public const string MachineName = "MachineName";
+
+        public static readonly UserAgent UserAgent = new UserAgent(Product, Version);
+        public static readonly Uri Uri = new Uri("https://pølse.med.lompe");
+    }
+}

--- a/source/Nrk.HttpRequester.UnitTests/UriBuilderTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/UriBuilderTests.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Specialized;
 using Shouldly;
 using Xunit;
 

--- a/source/Nrk.HttpRequester.UnitTests/UserAgentTest.cs
+++ b/source/Nrk.HttpRequester.UnitTests/UserAgentTest.cs
@@ -51,6 +51,15 @@ namespace Nrk.HttpRequester.UnitTests
             header.ShouldBe($"{Some.Product}/{Some.Version} {Some.DataCenter} {Some.MachineName}");
         }
 
+        [Fact]
+        public void Product_Version_Comment_Framework_Version_Comment()
+        {
+            var userAgent = new UserAgent(Some.Product, Some.Version, Some.Comment).Add(Some.Framework, Some.Version, Some.Comment);
+            var header = GetUserAgentHeader(userAgent);
+            _output.WriteLine(header);
+            header.ShouldBe($"{Some.Product}/{Some.Version} ({Some.Comment}) {Some.Framework}/{Some.Version} ({Some.Comment})");
+        }
+
         private static string GetUserAgentHeader(UserAgent userAgent)
         {
             var userAgentHeader = new HttpRequestMessage().Headers.UserAgent;

--- a/source/Nrk.HttpRequester.UnitTests/UserAgentTest.cs
+++ b/source/Nrk.HttpRequester.UnitTests/UserAgentTest.cs
@@ -1,0 +1,65 @@
+﻿using System.Net.Http;
+using System.Net.Http.Headers;
+using Nrk.HttpRequester.UnitTests.TestData;
+using Shouldly;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Nrk.HttpRequester.UnitTests
+{
+    public class UserAgentTest
+    {
+        private readonly ITestOutputHelper _output;
+
+        public UserAgentTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void Product_Version()
+        {
+            var userAgent = new UserAgent(Some.Product, Some.Version);
+            var header = GetUserAgentHeader(userAgent);
+            _output.WriteLine(header);
+            header.ShouldBe($"{Some.Product}/{Some.Version}");
+        }
+
+        [Fact]
+        public void Product_Version_Comment()
+        {
+            var userAgent = new UserAgent(Some.Product, Some.Version, Some.Comment);
+            var header = GetUserAgentHeader(userAgent);
+            _output.WriteLine(header);
+            header.ShouldBe($"{Some.Product}/{Some.Version} ({Some.Comment})");
+        }
+
+        [Fact]
+        public void Product_Version_DataCenter()
+        {
+            var userAgent = new UserAgent(Some.Product, Some.Version).Add(Some.DataCenter);
+            var header = GetUserAgentHeader(userAgent);
+            _output.WriteLine(header);
+            header.ShouldBe($"{Some.Product}/{Some.Version} {Some.DataCenter}");
+        }
+
+        [Fact]
+        public void Product_Version_DataCenter_MachineName()
+        {
+            var userAgent = new UserAgent(Some.Product, Some.Version).Add(Some.DataCenter).Add(Some.MachineName);
+            var header = GetUserAgentHeader(userAgent);
+            _output.WriteLine(header);
+            header.ShouldBe($"{Some.Product}/{Some.Version} {Some.DataCenter} {Some.MachineName}");
+        }
+
+        private static string GetUserAgentHeader(UserAgent userAgent)
+        {
+            var userAgentHeader = new HttpRequestMessage().Headers.UserAgent;
+            foreach (var info in userAgent.ToProductInfoHeaderValues())
+            {
+                userAgentHeader.Add(info);
+            }
+            return userAgentHeader.ToString();
+        }
+    }
+}

--- a/source/Nrk.HttpRequester.UnitTests/UserAgentTest.cs
+++ b/source/Nrk.HttpRequester.UnitTests/UserAgentTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Http;
-using System.Net.Http.Headers;
 using Nrk.HttpRequester.UnitTests.TestData;
 using Shouldly;
 using Xunit;

--- a/source/Nrk.HttpRequester.UnitTests/WebRequestHttpClientFactoryTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequestHttpClientFactoryTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using Nrk.HttpRequester.UnitTests.TestData;
 using Shouldly;
 using Xunit;
 
@@ -12,7 +13,16 @@ namespace Nrk.HttpRequester.UnitTests
         public void Create_NullBaseUrl_ShouldThrowArgumentNullException()
         {
             // Act
-            var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(null).Create());
+            var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(null, Some.UserAgent).Create());
+            // Assert
+            ex.ShouldBeOfType<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Create_NullUserAgent_ShouldThrowArgumentNullException()
+        {
+            // Act
+            var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(Some.Uri, null).Create());
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();
         }
@@ -25,7 +35,7 @@ namespace Nrk.HttpRequester.UnitTests
             var timeout = TimeSpan.FromSeconds(20);
 
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithTimeout(timeout).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithTimeout(timeout).Create();
 
             // Assert
             httpClient.Client.Timeout.ShouldBe(timeout);
@@ -36,7 +46,7 @@ namespace Nrk.HttpRequester.UnitTests
         {
             var baseUri = new Uri("http://fake.api.com");
             var timeout = TimeSpan.FromSeconds(20);
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithTimeout(timeout).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithTimeout(timeout).Create();
             httpClient.Client.Timeout.ShouldBe(timeout);
         }
 
@@ -48,7 +58,7 @@ namespace Nrk.HttpRequester.UnitTests
             var requestHeaders = new Dictionary<string, string> { { "headerKey", "headerValue" } };
 
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithDefaultRequestHeaders(requestHeaders).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithDefaultRequestHeaders(requestHeaders).Create();
             
             // Assert
             httpClient.Client.DefaultRequestHeaders.Contains("headerKey").ShouldBeTrue();
@@ -61,7 +71,7 @@ namespace Nrk.HttpRequester.UnitTests
             var baseUri = new Uri("http://fake.api.com");
             const int oneMinute = 60 * 1000;
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithConnectionLeaseTimeout(60*1000).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithConnectionLeaseTimeout(60*1000).Create();
 
             // Assert
             var connectionLeaseTimeout = ServicePointManager.FindServicePoint(baseUri).ConnectionLeaseTimeout;
@@ -75,7 +85,7 @@ namespace Nrk.HttpRequester.UnitTests
             var baseUri = new Uri("http://fake.api.com");
             const int defaultConnectionLease = -1;
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).Create();
 
             // Assert
             var connectionLeaseTimeout = ServicePointManager.FindServicePoint(baseUri).ConnectionLeaseTimeout;
@@ -91,7 +101,7 @@ namespace Nrk.HttpRequester.UnitTests
 
             const int oneMinute = 60 * 1000;
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithConnectionLeaseTimeout(60 * 1000).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithConnectionLeaseTimeout(60 * 1000).Create();
 
             // Assert
             var connectionLeaseTimeout = ServicePointManager.FindServicePoint(baseUriWithPath).ConnectionLeaseTimeout;

--- a/source/Nrk.HttpRequester.UnitTests/WebRequestHttpClientFactoryTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequestHttpClientFactoryTests.cs
@@ -13,16 +13,7 @@ namespace Nrk.HttpRequester.UnitTests
         public void Create_NullBaseUrl_ShouldThrowArgumentNullException()
         {
             // Act
-            var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(null, Some.UserAgent).Create());
-            // Assert
-            ex.ShouldBeOfType<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void Create_NullUserAgent_ShouldThrowArgumentNullException()
-        {
-            // Act
-            var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(Some.Uri, null).Create());
+            var ex = Record.Exception(() => WebRequestHttpClientFactory.Configure(null).Create());
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();
         }
@@ -35,10 +26,18 @@ namespace Nrk.HttpRequester.UnitTests
             var timeout = TimeSpan.FromSeconds(20);
 
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithTimeout(timeout).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithTimeout(timeout).Create();
 
             // Assert
             httpClient.Client.Timeout.ShouldBe(timeout);
+        }
+
+        [Fact]
+        public void Create_GivenUserAgent_SetsUserAgentHeader()
+        {
+            var client = WebRequestHttpClientFactory.Configure(Some.Uri).WithUserAgent(new UserAgent("application", "1.2.3", "With whistles and bells enabled")).Create();
+            var userAgentHeader = client.Client.DefaultRequestHeaders.UserAgent.ToString();
+            userAgentHeader.ShouldBe("application/1.2.3 (With whistles and bells enabled)");
         }
 
         [Fact]
@@ -46,7 +45,7 @@ namespace Nrk.HttpRequester.UnitTests
         {
             var baseUri = new Uri("http://fake.api.com");
             var timeout = TimeSpan.FromSeconds(20);
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithTimeout(timeout).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithTimeout(timeout).Create();
             httpClient.Client.Timeout.ShouldBe(timeout);
         }
 
@@ -58,7 +57,7 @@ namespace Nrk.HttpRequester.UnitTests
             var requestHeaders = new Dictionary<string, string> { { "headerKey", "headerValue" } };
 
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithDefaultRequestHeaders(requestHeaders).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithDefaultRequestHeaders(requestHeaders).Create();
             
             // Assert
             httpClient.Client.DefaultRequestHeaders.Contains("headerKey").ShouldBeTrue();
@@ -71,7 +70,7 @@ namespace Nrk.HttpRequester.UnitTests
             var baseUri = new Uri("http://fake.api.com");
             const int oneMinute = 60 * 1000;
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithConnectionLeaseTimeout(60*1000).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithConnectionLeaseTimeout(60*1000).Create();
 
             // Assert
             var connectionLeaseTimeout = ServicePointManager.FindServicePoint(baseUri).ConnectionLeaseTimeout;
@@ -85,7 +84,7 @@ namespace Nrk.HttpRequester.UnitTests
             var baseUri = new Uri("http://fake.api.com");
             const int defaultConnectionLease = -1;
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).Create();
 
             // Assert
             var connectionLeaseTimeout = ServicePointManager.FindServicePoint(baseUri).ConnectionLeaseTimeout;
@@ -101,7 +100,7 @@ namespace Nrk.HttpRequester.UnitTests
 
             const int oneMinute = 60 * 1000;
             // Act
-            var httpClient = WebRequestHttpClientFactory.Configure(baseUri, Some.UserAgent).WithConnectionLeaseTimeout(60 * 1000).Create();
+            var httpClient = WebRequestHttpClientFactory.Configure(baseUri).WithConnectionLeaseTimeout(60 * 1000).Create();
 
             // Assert
             var connectionLeaseTimeout = ServicePointManager.FindServicePoint(baseUriWithPath).ConnectionLeaseTimeout;

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Specialized;
 using System.Net.Http;
 using System.Threading.Tasks;
 using FakeItEasy;
+using Nrk.HttpRequester.UnitTests.TestData;
 using Shouldly;
 using Xunit;
 

--- a/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
+++ b/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
@@ -52,8 +52,10 @@
   <ItemGroup>
     <Compile Include="IHttpClient.cs" />
     <Compile Include="IWebRequester.cs" />
+    <Compile Include="ProductPart.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UriBuilder.cs" />
+    <Compile Include="UserAgent.cs" />
     <Compile Include="WebRequester.cs" />
     <Compile Include="WebRequestHttpClientFactory.cs" />
   </ItemGroup>

--- a/source/Nrk.HttpRequester/ProductPart.cs
+++ b/source/Nrk.HttpRequester/ProductPart.cs
@@ -1,0 +1,9 @@
+﻿namespace Nrk.HttpRequester
+{
+    public class ProductPart
+    {
+        public string Product { get; set; }
+        public string Version { get; set; }
+        public string Comment { get; set; }
+    }
+}

--- a/source/Nrk.HttpRequester/ProductPart.cs
+++ b/source/Nrk.HttpRequester/ProductPart.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nrk.HttpRequester
 {
-    public class ProductPart
+    internal class ProductPart
     {
         public string Product { get; set; }
         public string Version { get; set; }

--- a/source/Nrk.HttpRequester/UserAgent.cs
+++ b/source/Nrk.HttpRequester/UserAgent.cs
@@ -8,7 +8,7 @@ namespace Nrk.HttpRequester
         private readonly List<ProductPart> _parts = new List<ProductPart>();
 
         /// <summary>
-        /// PsApi/1.0.0
+        /// MyApplication/1.0.0
         /// </summary>
         /// <param name="product"></param>
         /// <param name="version"></param>
@@ -19,7 +19,7 @@ namespace Nrk.HttpRequester
 
 
         /// <summary>
-        /// PsApi/1.0.0 (This is a comment)
+        /// MyApplication/1.0.0 (This is a comment)
         /// </summary>
         /// <param name="product"></param>
         /// <param name="version"></param>
@@ -30,7 +30,7 @@ namespace Nrk.HttpRequester
         }
 
         /// <summary>
-        /// PsApi
+        /// MyApplication
         /// </summary>
         /// <param name="product"></param>
         /// <returns></returns>
@@ -44,7 +44,7 @@ namespace Nrk.HttpRequester
 
 
         /// <summary>
-        /// PsApi/1.0.0
+        /// MyApplication/1.0.0
         /// </summary>
         /// <param name="productName"></param>
         /// <param name="version"></param>
@@ -60,7 +60,7 @@ namespace Nrk.HttpRequester
 
 
         /// <summary>
-        /// PsApi/1.0.0 (This is a comment)
+        /// MyApplication/1.0.0 (This is a comment)
         /// </summary>
         /// <param name="productName"></param>
         /// <param name="version"></param>

--- a/source/Nrk.HttpRequester/UserAgent.cs
+++ b/source/Nrk.HttpRequester/UserAgent.cs
@@ -1,0 +1,113 @@
+﻿using System.Collections.Generic;
+using System.Net.Http.Headers;
+
+namespace Nrk.HttpRequester
+{
+    public class UserAgent
+    {
+        private readonly List<ProductPart> _parts = new List<ProductPart>();
+
+        /// <summary>
+        /// PsApi/1.0.0
+        /// </summary>
+        /// <param name="product"></param>
+        /// <param name="version"></param>
+        public UserAgent(string product, string version)
+        {
+            Add(product, version);
+        }
+
+
+        /// <summary>
+        /// PsApi/1.0.0 (This is a comment)
+        /// </summary>
+        /// <param name="product"></param>
+        /// <param name="version"></param>
+        /// <param name="comment"></param>
+        public UserAgent(string product, string version, string comment)
+        {
+            Add(product, version, comment);
+        }
+
+        /// <summary>
+        /// PsApi
+        /// </summary>
+        /// <param name="product"></param>
+        /// <returns></returns>
+        public UserAgent Add(string product)
+        {
+            return Add(new ProductPart
+            {
+                Product = product
+            });
+        }
+
+
+        /// <summary>
+        /// PsApi/1.0.0
+        /// </summary>
+        /// <param name="productName"></param>
+        /// <param name="version"></param>
+        /// <returns></returns>
+        public UserAgent Add(string productName, string version)
+        {
+            return Add(new ProductPart
+            {
+                Product = productName,
+                Version = version
+            });
+        }
+
+
+        /// <summary>
+        /// PsApi/1.0.0 (This is a comment)
+        /// </summary>
+        /// <param name="productName"></param>
+        /// <param name="version"></param>
+        /// <param name="comment"></param>
+        /// <returns></returns>
+        public UserAgent Add(string productName, string version, string comment)
+        {
+            return Add(new ProductPart
+            {
+                Product = productName,
+                Version = version,
+                Comment = comment
+            });
+        }
+
+        private UserAgent Add(ProductPart part)
+        {
+            _parts.Add(part);
+            return this;
+        }
+
+        public IEnumerable<ProductInfoHeaderValue> ToProductInfoHeaderValues()
+        {
+            foreach (var part in _parts)
+            {
+                if (string.IsNullOrWhiteSpace(part.Version))
+                {
+                    yield return new ProductInfoHeaderValue(new ProductHeaderValue(part.Product));
+                }
+                else
+                {
+                    yield return new ProductInfoHeaderValue(part.Product, part.Version);
+                }
+                var comment = part.Comment;
+                if (!string.IsNullOrWhiteSpace(comment))
+                {
+                    if (!comment.StartsWith("("))
+                    {
+                        comment = $"({comment}";
+                    }
+                    if (!comment.EndsWith(")"))
+                    {
+                        comment = $"{comment})";
+                    }
+                    yield return new ProductInfoHeaderValue(comment);
+                }
+            }
+        }
+    }
+}

--- a/source/Nrk.HttpRequester/UserAgent.cs
+++ b/source/Nrk.HttpRequester/UserAgent.cs
@@ -3,15 +3,31 @@ using System.Net.Http.Headers;
 
 namespace Nrk.HttpRequester
 {
+    /// <summary>
+    /// Builder for User-Agent header
+    /// </summary>
     public class UserAgent
     {
         private readonly List<ProductPart> _parts = new List<ProductPart>();
 
         /// <summary>
+        /// Creates a new <code>UserAgent</code> with
+        /// product, e.g.
+        /// MyApplication
+        /// </summary>
+        /// <param name="product">e.g. MyApplication</param>
+        public UserAgent(string product)
+        {
+            Add(product);
+        }
+
+        /// <summary>
+        /// Creates a new <code>UserAgent</code> with
+        /// product/version e.g.
         /// MyApplication/1.0.0
         /// </summary>
-        /// <param name="product"></param>
-        /// <param name="version"></param>
+        /// <param name="product">e.g. MyApplication</param>
+        /// <param name="version">e.g. 1.0.0</param>
         public UserAgent(string product, string version)
         {
             Add(product, version);
@@ -19,21 +35,23 @@ namespace Nrk.HttpRequester
 
 
         /// <summary>
+        /// Creates a new <code>UserAgent</code> with
+        /// product/version (comment), e.g.
         /// MyApplication/1.0.0 (This is a comment)
         /// </summary>
-        /// <param name="product"></param>
-        /// <param name="version"></param>
-        /// <param name="comment"></param>
+        /// <param name="product">e.g. MyApplication</param>
+        /// <param name="version">e.g. 1.0.0</param>
+        /// <param name="comment">e.g. This is a comment</param>
         public UserAgent(string product, string version, string comment)
         {
             Add(product, version, comment);
         }
 
         /// <summary>
-        /// MyApplication
+        /// Adds product
         /// </summary>
-        /// <param name="product"></param>
-        /// <returns></returns>
+        /// <param name="product">e.g. MyApplication</param>
+        /// <returns>this UserAgent</returns>
         public UserAgent Add(string product)
         {
             return Add(new ProductPart
@@ -44,33 +62,33 @@ namespace Nrk.HttpRequester
 
 
         /// <summary>
-        /// MyApplication/1.0.0
+        /// Adds product/version, 
         /// </summary>
-        /// <param name="productName"></param>
-        /// <param name="version"></param>
-        /// <returns></returns>
-        public UserAgent Add(string productName, string version)
+        /// <param name="product">e.g. MyApplication</param>
+        /// <param name="version">e.g. 1.0.0</param>
+        /// <returns>this UserAgent</returns>
+        public UserAgent Add(string product, string version)
         {
             return Add(new ProductPart
             {
-                Product = productName,
+                Product = product,
                 Version = version
             });
         }
 
 
         /// <summary>
-        /// MyApplication/1.0.0 (This is a comment)
+        /// Adds product/version (comment)
         /// </summary>
-        /// <param name="productName"></param>
-        /// <param name="version"></param>
-        /// <param name="comment"></param>
+        /// <param name="product">e.g. MyApplication</param>
+        /// <param name="version">e.g. 1.0.0</param>
+        /// <param name="comment">e.g. This is a comment</param>
         /// <returns></returns>
-        public UserAgent Add(string productName, string version, string comment)
+        public UserAgent Add(string product, string version, string comment)
         {
             return Add(new ProductPart
             {
-                Product = productName,
+                Product = product,
                 Version = version,
                 Comment = comment
             });


### PR DESCRIPTION
Support for setting User-Agent header with blocks of product[/version] [(comment)], according to https://tools.ietf.org/html/rfc7230#section-3.2.
Product is required, version and comment are optional.

UserAgent may contain multiple blocks:
MyAppliaction/1.0.0 (Whistles and bells enabled) MyFramework/3.14 (This is awesome) 
