### PR TITLE
DNC-1031 Clone Request in order to retry that request.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@
   branches:
     only:
       - master
-  version: 1.2.{build}
+  version: 2.0.{build}
   build_script:
     build.cmd version=%APPVEYOR_BUILD_VERSION%
   test: off

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -45,12 +45,13 @@ namespace Nrk.HttpRequester.UnitTests
         public async Task GetResponseAsync_WithRetriesAndCloning_ShouldRetrySendAsync()
         {
             // Arrange
+            var enableCloning = true;
             var httpClient = A.Fake<IHttpClient>();
             A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).Throws<TaskCanceledException>().NumberOfTimes(1);
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1));
+            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1), null, null, enableCloning);
 
             // Act
-            await requester.GetResponseAsync("/test", retries: 3, allowCloning: true);
+            await requester.GetResponseAsync("/test", retries: 3);
 
             // Assert
             A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened(Repeated.Exactly.Times(2));

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -42,6 +42,21 @@ namespace Nrk.HttpRequester.UnitTests
         }
 
         [Fact]
+        public async Task GetResponseAsync_WithRetriesAndCloning_ShouldRetrySendAsync()
+        {
+            // Arrange
+            var httpClient = A.Fake<IHttpClient>();
+            A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).Throws<TaskCanceledException>().NumberOfTimes(1);
+            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1));
+
+            // Act
+            await requester.GetResponseAsync("/test", retries: 3, allowCloning: true);
+
+            // Assert
+            A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened(Repeated.Exactly.Times(2));
+        }
+
+        [Fact]
         public async Task GetResponseAsync_WithRetries_WithMultipleExceptions_ShouldRetrySendAsync()
         {
             // Arrange

--- a/source/Nrk.HttpRequester/HttpRequestMessageExtensions.cs
+++ b/source/Nrk.HttpRequester/HttpRequestMessageExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Net.Http;
+
+namespace Nrk.HttpRequester
+{
+    public static class HttpRequestMessageExtensions
+    {
+
+        public static HttpRequestMessage Clone(this HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri)
+            {
+                Content = request.Content,
+                Version = request.Version
+            };
+
+            foreach (var property in request.Properties)
+            {
+                clone.Properties.Add(property);
+            }
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
+        }
+    }
+}

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -7,14 +7,14 @@ namespace Nrk.HttpRequester
 {
     public interface IWebRequester
     {
-        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string path, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-	    Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
+        Task<string> GetResponseAsStringAsync(string path, int retries = 0, bool allowCloning = false);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0, bool allowCloning = false);
+        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
+	    Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0, bool allowCloning = false);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0, bool allowCloning = false);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content);
         Task<HttpResponseMessage> PutAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
@@ -28,7 +28,7 @@ namespace Nrk.HttpRequester
         /// Direct access to underlying http client
         /// </summary>
         Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request);
-        Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries);
+        Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries, bool allowCloning = false);
     }
 
 

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -7,14 +7,14 @@ namespace Nrk.HttpRequester
 {
     public interface IWebRequester
     {
-        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
-        Task<string> GetResponseAsStringAsync(string path, int retries = 0, bool allowCloning = false);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0, bool allowCloning = false);
-        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
-	    Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0, bool allowCloning = false);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0, bool allowCloning = false);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0, bool allowCloning = false);
+        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string path, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
+        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
+	    Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content);
         Task<HttpResponseMessage> PutAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
@@ -28,7 +28,7 @@ namespace Nrk.HttpRequester
         /// Direct access to underlying http client
         /// </summary>
         Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request);
-        Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries, bool allowCloning = false);
+        Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries);
     }
 
 

--- a/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
+++ b/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
@@ -30,17 +30,22 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Polly, Version=5.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Polly.5.0.5\lib\net45\Polly.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Polly, Version=6.0.0.0, Culture=neutral, PublicKeyToken=c8a3ffc3f8f825cc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Polly.6.1.0\lib\netstandard1.1\Polly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -50,6 +55,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="HttpRequestMessageExtensions.cs" />
     <Compile Include="IHttpClient.cs" />
     <Compile Include="IWebRequester.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/source/Nrk.HttpRequester/packages.config
+++ b/source/Nrk.HttpRequester/packages.config
@@ -1,5 +1,37 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
-  <package id="Polly" version="5.0.5" targetFramework="net452" />
+  <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
+  <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
+  <package id="Polly" version="6.1.0" targetFramework="net452" />
+  <package id="System.Collections" version="4.3.0" targetFramework="net452" />
+  <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tools" version="4.3.0" targetFramework="net452" />
+  <package id="System.Diagnostics.Tracing" version="4.3.0" targetFramework="net452" />
+  <package id="System.Globalization" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO" version="4.3.0" targetFramework="net452" />
+  <package id="System.IO.Compression" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq" version="4.3.0" targetFramework="net452" />
+  <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Http" version="4.3.0" targetFramework="net452" />
+  <package id="System.Net.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
+  <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
+  <package id="System.Runtime.Numerics" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.Encoding.Extensions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Text.RegularExpressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" />
+  <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Problem was: 
Trying to resend the same HttpRequestMessage with each retry - which results in an exception: "The request message was already sent. Cannot send the same request message multiple times."

Solution was:
Clone the request, use that cloned request for each attempt at a retry.

Also added a list of Reponses we should retry on.

Note: requires Polly 6.1