### PR TITLE
DNC-1399 Remove retry functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ var childRequester = webRequester.With(m => m.Headers.Add("request-specific-head
 The following methods are available from IWebRequester:
 
 ```cs
-        Task<string> GetResponseAsStringAsync(string url, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string url, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string url);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters);
+        Task<HttpResponseMessage> GetResponseAsync(string url);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters);
 ```
 
 You can either send a path `example/path/123` or a [URI Template](https://tools.ietf.org/html/rfc6570) string with matching parameters in a [`NameValueCollection`](https://msdn.microsoft.com/en-us/library/system.collections.specialized.namevaluecollection(v=vs.110).aspx):

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@
   branches:
     only:
       - master
-  version: 1.2.{build}
+  version: 2.0.{build}
   build_script:
     build.cmd version=%APPVEYOR_BUILD_VERSION%
   test: off

--- a/build.fsx
+++ b/build.fsx
@@ -64,7 +64,8 @@ Target "CreateNugetPackage" (fun _ ->
       WorkingDir = buildDir
       Publish = false
       Dependencies =
-        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"]
+        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client",
+		"Newtonsoft.Json", "./source/packages/" "Newtonsoft.Json"]
       Files =
         [(@"Nrk.HttpRequester.dll", Some @"lib\net45", None)
          (@"Nrk.HttpRequester.pdb", Some @"lib\net45", None)]

--- a/build.fsx
+++ b/build.fsx
@@ -64,8 +64,8 @@ Target "CreateNugetPackage" (fun _ ->
       WorkingDir = buildDir
       Publish = false
       Dependencies =
-        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client",
-        "Newtonsoft.Json", "./source/packages/" "Newtonsoft.Json"]
+        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"
+        "Newtonsoft.Json", GetPackageVersion "./source/packages/" "Newtonsoft.Json"]
       Files =
         [(@"Nrk.HttpRequester.dll", Some @"lib\net45", None)
          (@"Nrk.HttpRequester.pdb", Some @"lib\net45", None)]

--- a/build.fsx
+++ b/build.fsx
@@ -64,8 +64,7 @@ Target "CreateNugetPackage" (fun _ ->
       WorkingDir = buildDir
       Publish = false
       Dependencies =
-        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"
-         "Newtonsoft.Json", GetPackageVersion "./source/packages/" "Newtonsoft.Json"]
+        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"]
       Files =
         [(@"Nrk.HttpRequester.dll", Some @"lib\net45", None)
          (@"Nrk.HttpRequester.pdb", Some @"lib\net45", None)]

--- a/build.fsx
+++ b/build.fsx
@@ -64,8 +64,7 @@ Target "CreateNugetPackage" (fun _ ->
       WorkingDir = buildDir
       Publish = false
       Dependencies =
-        ["Polly", GetPackageVersion "./source/packages/" "Polly"
-         "Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"]
+        ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"]
       Files =
         [(@"Nrk.HttpRequester.dll", Some @"lib\net45", None)
          (@"Nrk.HttpRequester.pdb", Some @"lib\net45", None)]

--- a/build.fsx
+++ b/build.fsx
@@ -65,7 +65,7 @@ Target "CreateNugetPackage" (fun _ ->
       Publish = false
       Dependencies =
         ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client",
-		"Newtonsoft.Json", "./source/packages/" "Newtonsoft.Json"]
+        "Newtonsoft.Json", "./source/packages/" "Newtonsoft.Json"]
       Files =
         [(@"Nrk.HttpRequester.dll", Some @"lib\net45", None)
          (@"Nrk.HttpRequester.pdb", Some @"lib\net45", None)]

--- a/build.fsx
+++ b/build.fsx
@@ -65,7 +65,7 @@ Target "CreateNugetPackage" (fun _ ->
       Publish = false
       Dependencies =
         ["Microsoft.AspNet.WebApi.Client", GetPackageVersion "./source/packages/" "Microsoft.AspNet.WebApi.Client"
-        "Newtonsoft.Json", GetPackageVersion "./source/packages/" "Newtonsoft.Json"]
+         "Newtonsoft.Json", GetPackageVersion "./source/packages/" "Newtonsoft.Json"]
       Files =
         [(@"Nrk.HttpRequester.dll", Some @"lib\net45", None)
          (@"Nrk.HttpRequester.pdb", Some @"lib\net45", None)]

--- a/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
+++ b/source/Nrk.HttpRequester.IntegrationTests/Nrk.HttpRequester.IntegrationTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -39,48 +39,40 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.4.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Host.HttpListener.4.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin.Hosting, Version=4.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Owin.Hosting.4.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.1.4.1\lib\net40\Nancy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nancy, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.2.0.0\lib\net452\Nancy.dll</HintPath>
     </Reference>
-    <Reference Include="Nancy.Owin, Version=1.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Nancy.Owin.1.4.1\lib\net40\Nancy.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Nancy.Owin, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Nancy.Owin.2.0.0\lib\net452\Nancy.Owin.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.2.8.2\lib\net451\Shouldly.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Shouldly, Version=3.0.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.3.0.2\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.0.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -102,6 +94,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -134,7 +127,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
+++ b/source/Nrk.HttpRequester.IntegrationTests/TestServer/Server.cs
@@ -1,8 +1,9 @@
-﻿using System.Linq;
-using System.Threading;
-using Nancy;
-using Nancy.Extensions;
+﻿using Nancy;
 using Owin;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
 
 namespace Nrk.HttpRequester.IntegrationTests.TestServer
 {
@@ -10,35 +11,36 @@ namespace Nrk.HttpRequester.IntegrationTests.TestServer
     {
         public ServerModule()
         {
-            Get["/get"] = _ => "success";
 
-            Put["/put"] = _ => "success";
+            Get("/get", args => "success");
 
-            Post["/post"] = _ => "success";
+            Put("/put", args => "success");
 
-            Delete["/delete"] = _ => "success";
+            Post("/post", args => "success");
 
-            Put["/put/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
-            
-            Post["/post/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
+            Delete("/delete", args => "success");
 
-            Delete["/delete/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
+            Put("/put/headers", args => Response.AsJson(Request.Headers.ToArray()));
 
-            Get["/get/headers"] = _ => Response.AsJson(Request.Headers.ToArray());
+            Post("/post/headers", args => Response.AsJson(Request.Headers.ToArray()));
 
-            Get["/get/cookies"] = _ => Response.AsJson(Request.Cookies);
+            Delete("/delete/headers", args => Response.AsJson(Request.Headers.ToArray()));
 
-            Put["/put/content"] = _ => Request.Body.AsString();
+            Get("/get/headers", args => Response.AsJson(Request.Headers.ToArray()));
 
-            Post["/post/content"] = _ => Request.Body.AsString();
-            
-            Delete["/delete/content"] = _ => Request.Body.AsString();
+            Get("/get/cookies", args => Response.AsJson(Request.Cookies));
 
-            Get["/delay/{ms:int}"] = parameters =>
+            Put("/put/content", args => new StreamReader(Request.Body).ReadToEnd());
+
+            Post("/post/content", args => new StreamReader(Request.Body).ReadToEnd());
+
+            Delete("/delete/content", args => new StreamReader(Request.Body).ReadToEnd());
+
+            Get("/delay/{ms:int}", args =>
             {
-                Thread.Sleep(parameters.ms);
-                return $"Finished sleeping for {parameters.ms}ms";
-            };
+                Thread.Sleep(TimeSpan.FromMilliseconds(args.ms));
+                return $"Finished sleeping for {args.ms}ms";
+            });
 
         }
     }

--- a/source/Nrk.HttpRequester.IntegrationTests/app.config
+++ b/source/Nrk.HttpRequester.IntegrationTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/source/Nrk.HttpRequester.IntegrationTests/packages.config
+++ b/source/Nrk.HttpRequester.IntegrationTests/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
-  <package id="Nancy" version="1.4.1" targetFramework="net452" />
-  <package id="Nancy.Owin" version="1.4.1" targetFramework="net452" />
+  <package id="Microsoft.Owin" version="4.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="4.0.1" targetFramework="net452" />
+  <package id="Microsoft.Owin.Hosting" version="4.0.1" targetFramework="net452" />
+  <package id="Nancy" version="2.0.0" targetFramework="net452" />
+  <package id="Nancy.Owin" version="2.0.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
-  <package id="Shouldly" version="2.8.2" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net452" developmentDependency="true" />
+  <package id="Shouldly" version="3.0.2" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/source/Nrk.HttpRequester.UnitTests/Nrk.HttpRequester.UnitTests.csproj
+++ b/source/Nrk.HttpRequester.UnitTests/Nrk.HttpRequester.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -38,27 +38,23 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=2.3.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\packages\FakeItEasy.2.3.3\lib\net40\FakeItEasy.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\packages\FakeItEasy.5.1.1\lib\net45\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="Shouldly, Version=2.8.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\packages\Shouldly.2.8.2\lib\net451\Shouldly.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Shouldly, Version=3.0.2.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
+      <HintPath>..\packages\Shouldly.3.0.2\lib\net451\Shouldly.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\xunit.abstractions.2.0.3\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.4.1\lib\net452\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.0.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.4.1.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.4.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -77,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -109,7 +106,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.3.1\build\net20\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.4.1\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/source/Nrk.HttpRequester.UnitTests/UriBuilderTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/UriBuilderTests.cs
@@ -1,10 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using Shouldly;
 using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Shouldly;
 using Xunit;
 
 namespace Nrk.HttpRequester.UnitTests

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -26,36 +26,6 @@ namespace Nrk.HttpRequester.UnitTests
         }
 
         [Fact]
-        public async Task GetResponseAsync_WithRetries_ShouldRetrySendAsync()
-        {
-            // Arrange
-            var httpClient = A.Fake<IHttpClient>();
-            A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).Throws<TaskCanceledException>().NumberOfTimes(1);
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1));
-
-            // Act
-            await requester.GetResponseAsync("/test", retries: 3);
-
-            // Assert
-            A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).MustHaveHappened(Repeated.Exactly.Times(2));
-        }
-
-        [Fact]
-        public async Task GetResponseAsync_WithRetries_ShouldOnlyRetryGivenAmountOfTimes()
-        {
-            // Arrange
-            var httpClient = A.Fake<IHttpClient>();
-            A.CallTo(() => httpClient.SendAsync(A<HttpRequestMessage>.Ignored)).Throws<TaskCanceledException>();
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1));
-
-            // Act
-            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsync("/test", retries: 3); });
-
-            // Assert
-            ex.ShouldBeOfType<TaskCanceledException>();
-        }
-
-        [Fact]
         public async Task GetResponseAsStringAsync_NullResponse_ShouldReturnEmptyString()
         {
             // Arrange
@@ -105,7 +75,7 @@ namespace Nrk.HttpRequester.UnitTests
             var requester = new WebRequester(httpClient);
 
             // Act
-            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsync("/test", null, null, 0); });
+            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsync("/test", null, null); });
 
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();
@@ -119,7 +89,7 @@ namespace Nrk.HttpRequester.UnitTests
             var requester = new WebRequester(httpClient);
 
             // Act
-            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsStringAsync("/test", null, null, 0); });
+            var ex = await Record.ExceptionAsync(async () => { await requester.GetResponseAsStringAsync("/test", null, null); });
 
             // Assert
             ex.ShouldBeOfType<ArgumentNullException>();
@@ -203,7 +173,7 @@ namespace Nrk.HttpRequester.UnitTests
                     () =>
                         httpClient.Client)
                 .Returns(_basicClient);
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1), defaultParams);
+            var requester = new WebRequester(httpClient, defaultParams);
 
             // Act
             await requester.GetResponseAsync(template, parameters);
@@ -233,7 +203,7 @@ namespace Nrk.HttpRequester.UnitTests
                     () =>
                         httpClient.Client)
                 .Returns(_basicClient);
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1), defaultParams);
+            var requester = new WebRequester(httpClient, defaultParams);
 
             // Act
             await requester.GetResponseAsync(url);
@@ -263,11 +233,11 @@ namespace Nrk.HttpRequester.UnitTests
                     () =>
                         httpClient.Client)
                 .Returns(_basicClient);
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1), defaultParams);
+            var requester = new WebRequester(httpClient, defaultParams);
 
             // Act
             var request = new HttpRequestMessage(HttpMethod.Get, url);
-            await requester.SendMessageAsyncWithRetries(request, 0);
+            await requester.SendMessageAsync(request);
 
             // Assert
             A.CallTo(
@@ -294,7 +264,7 @@ namespace Nrk.HttpRequester.UnitTests
                     () =>
                         httpClient.Client)
                 .Returns(_basicClient);
-            var requester = new WebRequester(httpClient, TimeSpan.FromMilliseconds(1), defaultParams);
+            var requester = new WebRequester(httpClient, defaultParams);
 
             // Act
             await requester.GetResponseAsync(url);
@@ -306,5 +276,6 @@ namespace Nrk.HttpRequester.UnitTests
                         A<HttpRequestMessage>.That.Matches(req => req.RequestUri.ToString().Equals(expectedUrl)))
             ).MustHaveHappened();
         }
+
     }
 }

--- a/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
+++ b/source/Nrk.HttpRequester.UnitTests/WebRequesterTests.cs
@@ -15,8 +15,8 @@ namespace Nrk.HttpRequester.UnitTests
 
         public WebRequesterTests()
         {
-            var baseAdress = new Uri("http://baseadress.com");
-            var client = new HttpClient { BaseAddress = baseAdress };
+            var baseAddress = new Uri("http://baseadress.com");
+            var client = new HttpClient { BaseAddress = baseAddress };
 
             _basicClient = client;
             _basicResponse = new HttpResponseMessage

--- a/source/Nrk.HttpRequester.UnitTests/app.config
+++ b/source/Nrk.HttpRequester.UnitTests/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/source/Nrk.HttpRequester.UnitTests/packages.config
+++ b/source/Nrk.HttpRequester.UnitTests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="2.3.3" targetFramework="net452" />
-  <package id="Shouldly" version="2.8.2" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.runner.visualstudio" version="2.3.1" targetFramework="net452" developmentDependency="true" />
+  <package id="FakeItEasy" version="5.1.1" targetFramework="net452" />
+  <package id="Shouldly" version="3.0.2" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.3" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.4.1" targetFramework="net452" />
+  <package id="xunit.runner.visualstudio" version="2.4.1" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/source/Nrk.HttpRequester/IWebRequester.cs
+++ b/source/Nrk.HttpRequester/IWebRequester.cs
@@ -7,14 +7,14 @@ namespace Nrk.HttpRequester
 {
     public interface IWebRequester
     {
-        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string path, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-	    Task<HttpResponseMessage> GetResponseAsync(string path, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader, int retries = 0);
-        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, int retries = 0);
+        Task<string> GetResponseAsStringAsync(string path, AuthenticationHeaderValue authenticationHeader);
+        Task<string> GetResponseAsStringAsync(string path);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader);
+        Task<string> GetResponseAsStringAsync(string pathTemplate, NameValueCollection parameters);
+        Task<HttpResponseMessage> GetResponseAsync(string path, AuthenticationHeaderValue authenticationHeader);
+	    Task<HttpResponseMessage> GetResponseAsync(string path);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters, AuthenticationHeaderValue authenticationHeader);
+        Task<HttpResponseMessage> GetResponseAsync(string pathTemplate, NameValueCollection parameters);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
         Task<HttpResponseMessage> PostAsync(string path, StringContent content);
         Task<HttpResponseMessage> PutAsync(string path, StringContent content, AuthenticationHeaderValue authenticationHeader);
@@ -28,7 +28,6 @@ namespace Nrk.HttpRequester
         /// Direct access to underlying http client
         /// </summary>
         Task<HttpResponseMessage> SendMessageAsync(HttpRequestMessage request);
-        Task<HttpResponseMessage> SendMessageAsyncWithRetries(HttpRequestMessage request, int retries);
     }
 
 

--- a/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
+++ b/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
@@ -30,10 +30,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Polly, Version=5.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Polly.5.0.5\lib\net45\Polly.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
+++ b/source/Nrk.HttpRequester/Nrk.HttpRequester.csproj
@@ -30,11 +30,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.3.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.3\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.ServiceModel" />
@@ -55,6 +57,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include=".editorconfig" />
+    <None Include="app.config" />
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersionAttribute("0.0.0")]
 [assembly: AssemblyFileVersionAttribute("0.0.0")]
 [assembly: GuidAttribute("d51e7a23-73d5-49a1-be63-f73e432e9ab3")]
-[assembly: AssemblyMetadataAttribute("githash","3ee2b2643de06190b373ec9ff327a470786ef524")]
+[assembly: AssemblyMetadataAttribute("githash","aa592ae678d73066d8936e67b3386a2011f252f4")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "NRK.HttpRequester";
@@ -19,6 +19,6 @@ namespace System {
         internal const System.String AssemblyInformationalVersion = "0.0.0";
         internal const System.String AssemblyFileVersion = "0.0.0";
         internal const System.String Guid = "d51e7a23-73d5-49a1-be63-f73e432e9ab3";
-        internal const System.String AssemblyMetadata_githash = "3ee2b2643de06190b373ec9ff327a470786ef524";
+        internal const System.String AssemblyMetadata_githash = "aa592ae678d73066d8936e67b3386a2011f252f4";
     }
 }

--- a/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
@@ -5,20 +5,20 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitleAttribute("NRK.HttpRequester")]
 [assembly: AssemblyProductAttribute("NRK.HttpRequester")]
 [assembly: AssemblyDescriptionAttribute("Library for sending Http Requests, including a fluent interface for creating HttpClient instances")]
-[assembly: AssemblyVersionAttribute("1.0.0")]
-[assembly: AssemblyInformationalVersionAttribute("1.0.0")]
-[assembly: AssemblyFileVersionAttribute("1.0.0")]
+[assembly: AssemblyVersionAttribute("0.0.0")]
+[assembly: AssemblyInformationalVersionAttribute("0.0.0")]
+[assembly: AssemblyFileVersionAttribute("0.0.0")]
 [assembly: GuidAttribute("d51e7a23-73d5-49a1-be63-f73e432e9ab3")]
-[assembly: AssemblyMetadataAttribute("githash","df607ccdd20d7d6946fc93bc382c4734a81a3be5")]
+[assembly: AssemblyMetadataAttribute("githash","3ff1ecef9a12794f0f7bcbe2f9e9c1b0a2c91f2a")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "NRK.HttpRequester";
         internal const System.String AssemblyProduct = "NRK.HttpRequester";
         internal const System.String AssemblyDescription = "Library for sending Http Requests, including a fluent interface for creating HttpClient instances";
-        internal const System.String AssemblyVersion = "1.0.0";
-        internal const System.String AssemblyInformationalVersion = "1.0.0";
-        internal const System.String AssemblyFileVersion = "1.0.0";
+        internal const System.String AssemblyVersion = "0.0.0";
+        internal const System.String AssemblyInformationalVersion = "0.0.0";
+        internal const System.String AssemblyFileVersion = "0.0.0";
         internal const System.String Guid = "d51e7a23-73d5-49a1-be63-f73e432e9ab3";
-        internal const System.String AssemblyMetadata_githash = "df607ccdd20d7d6946fc93bc382c4734a81a3be5";
+        internal const System.String AssemblyMetadata_githash = "3ff1ecef9a12794f0f7bcbe2f9e9c1b0a2c91f2a";
     }
 }

--- a/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
+++ b/source/Nrk.HttpRequester/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersionAttribute("0.0.0")]
 [assembly: AssemblyFileVersionAttribute("0.0.0")]
 [assembly: GuidAttribute("d51e7a23-73d5-49a1-be63-f73e432e9ab3")]
-[assembly: AssemblyMetadataAttribute("githash","3ff1ecef9a12794f0f7bcbe2f9e9c1b0a2c91f2a")]
+[assembly: AssemblyMetadataAttribute("githash","3ee2b2643de06190b373ec9ff327a470786ef524")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "NRK.HttpRequester";
@@ -19,6 +19,6 @@ namespace System {
         internal const System.String AssemblyInformationalVersion = "0.0.0";
         internal const System.String AssemblyFileVersion = "0.0.0";
         internal const System.String Guid = "d51e7a23-73d5-49a1-be63-f73e432e9ab3";
-        internal const System.String AssemblyMetadata_githash = "3ff1ecef9a12794f0f7bcbe2f9e9c1b0a2c91f2a";
+        internal const System.String AssemblyMetadata_githash = "3ee2b2643de06190b373ec9ff327a470786ef524";
     }
 }

--- a/source/Nrk.HttpRequester/app.config
+++ b/source/Nrk.HttpRequester/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-12.0.0.0" newVersion="12.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/source/Nrk.HttpRequester/packages.config
+++ b/source/Nrk.HttpRequester/packages.config
@@ -1,5 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
-  <package id="Polly" version="5.0.5" targetFramework="net452" />
 </packages>

--- a/source/Nrk.HttpRequester/packages.config
+++ b/source/Nrk.HttpRequester/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
The currently implemented retry functionality in the WebRequester does not take into acocunt that some requests cannot be re-tried.
An attempt was made to stop errors surrounding this, in https://github.com/nrkno/Nrk.HttpRequester/pull/18 , however, this did not alleviate all concerns.

Instead, moving the responsibility for retries to each individual client instead would be the best plan of action.

This PR bumps the version to 2, as it's a breaking change. It also removes all retry-functionality, and the dependency on Polly.

It allows us to close:
https://github.com/nrkno/Nrk.HttpRequester/pull/18
https://github.com/nrkno/Nrk.HttpRequester/pull/9
https://github.com/nrkno/Nrk.HttpRequester/issues/8